### PR TITLE
Fix: No more missing MCP2515 events because the MCP2515 keeps the INTline low UNTIL all EVENTS have been handled.

### DIFF
--- a/examples/OpenCyphal-Blink/OpenCyphal-Blink.ino
+++ b/examples/OpenCyphal-Blink/OpenCyphal-Blink.ino
@@ -97,7 +97,7 @@ void setup()
 
   /* Attach interrupt handler to register MCP2515 signaled by taking INT low */
   pinMode(MKRCAN_MCP2515_INT_PIN, INPUT_PULLUP);
-  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, FALLING);
+  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, LOW);
 
   /* Initialize MCP2515 */
   mcp2515.begin();

--- a/examples/OpenCyphal-GNSS-Node/OpenCyphal-GNSS-Node.ino
+++ b/examples/OpenCyphal-GNSS-Node/OpenCyphal-GNSS-Node.ino
@@ -133,7 +133,7 @@ void setup()
    * MCP2515 signaled by taking INT low.
    */
   pinMode(MKRCAN_MCP2515_INT_PIN, INPUT_PULLUP);
-  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, FALLING);
+  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, LOW);
 
   /* Configure MCP2515 */
   mcp2515.begin();

--- a/examples/OpenCyphal-Heartbeat-Publish/OpenCyphal-Heartbeat-Publish.ino
+++ b/examples/OpenCyphal-Heartbeat-Publish/OpenCyphal-Heartbeat-Publish.ino
@@ -59,7 +59,7 @@ void setup()
 
   /* Attach interrupt handler to register MCP2515 signaled by taking INT low */
   pinMode(MKRCAN_MCP2515_INT_PIN, INPUT_PULLUP);
-  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, FALLING);
+  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, LOW);
 
   /* Initialize MCP2515 */
   mcp2515.begin();

--- a/examples/OpenCyphal-Heartbeat-Subscribe/OpenCyphal-Heartbeat-Subscribe.ino
+++ b/examples/OpenCyphal-Heartbeat-Subscribe/OpenCyphal-Heartbeat-Subscribe.ino
@@ -64,7 +64,7 @@ void setup()
 
   /* Attach interrupt handler to register MCP2515 signaled by taking INT low */
   pinMode(MKRCAN_MCP2515_INT_PIN, INPUT_PULLUP);
-  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, FALLING);
+  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, LOW);
 
   /* Initialize MCP2515 */
   mcp2515.begin();

--- a/examples/OpenCyphal-Service-Client/OpenCyphal-Service-Client.ino
+++ b/examples/OpenCyphal-Service-Client/OpenCyphal-Service-Client.ino
@@ -65,7 +65,7 @@ void setup()
 
   /* Attach interrupt handler to register MCP2515 signaled by taking INT low */
   pinMode(MKRCAN_MCP2515_INT_PIN, INPUT_PULLUP);
-  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, FALLING);
+  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, LOW);
 
   /* Initialize MCP2515 */
   mcp2515.begin();

--- a/examples/OpenCyphal-Service-Server/OpenCyphal-Service-Server.ino
+++ b/examples/OpenCyphal-Service-Server/OpenCyphal-Service-Server.ino
@@ -65,7 +65,7 @@ void setup()
 
   /* Attach interrupt handler to register MCP2515 signaled by taking INT low */
   pinMode(MKRCAN_MCP2515_INT_PIN, INPUT_PULLUP);
-  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, FALLING);
+  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, LOW);
 
   /* Initialize MCP2515 */
   mcp2515.begin();

--- a/examples/OpenCyphal-ToF-Distance-Sensor-Node/OpenCyphal-ToF-Distance-Sensor-Node.ino
+++ b/examples/OpenCyphal-ToF-Distance-Sensor-Node/OpenCyphal-ToF-Distance-Sensor-Node.ino
@@ -151,7 +151,7 @@ void setup()
    * MCP2515 signaled by taking INT low.
    */
   pinMode(MKRCAN_MCP2515_INT_PIN, INPUT_PULLUP);
-  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, FALLING);
+  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, LOW);
 
   /* Configure MCP2515
    */


### PR DESCRIPTION
This fixes #154 .

Note: also ensure to get the [latest version](https://github.com/107-systems/107-Arduino-MCP2515) of 107-Arduino-MCP2515.