### PR TITLE
Only compile one board per architecture.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -34,37 +34,10 @@ jobs:
 
       matrix:
         board:
-          - fqbn: arduino:samd:mkr1000
-            platforms: |
-              - name: arduino:samd
           - fqbn: arduino:samd:mkrzero
             platforms: |
               - name: arduino:samd
-          - fqbn: arduino:samd:mkrwifi1010
-            platforms: |
-              - name: arduino:samd
-          - fqbn: arduino:samd:mkrfox1200
-            platforms: |
-              - name: arduino:samd
-          - fqbn: arduino:samd:mkrwan1300
-            platforms: |
-              - name: arduino:samd
-          - fqbn: arduino:samd:mkrwan1310
-            platforms: |
-              - name: arduino:samd
-          - fqbn: arduino:samd:mkrgsm1400
-            platforms: |
-              - name: arduino:samd
-          - fqbn: arduino:samd:mkrnb1500
-            platforms: |
-              - name: arduino:samd
-          - fqbn: arduino:samd:mkrvidor4000
-            platforms: |
-              - name: arduino:samd
           - fqbn: arduino:mbed_portenta:envie_m7
-            platforms: |
-              - name: arduino:mbed_portenta
-          - fqbn: arduino:mbed_portenta:envie_m4
             platforms: |
               - name: arduino:mbed_portenta
           - fqbn: arduino:mbed_nano:nano33ble


### PR DESCRIPTION
Compiling for numerous different boards for any given architecture (i.e. MKR 1000, MKR WiFi 1010, ... for arduino:samd) is a waste of time and computational ressources because this library does not make use of any board-specific code. If the CI compiles for one board, it compiles for any of them. Otherwise it would be a violation of the specific board of the Arduino API.