### PR TITLE
Fix: no need to make 107-Arduino-UniqueId an exclusive dependency.

### DIFF
--- a/examples/OpenCyphal-ToF-Distance-Sensor-Node/OpenCyphal-ToF-Distance-Sensor-Node.ino
+++ b/examples/OpenCyphal-ToF-Distance-Sensor-Node/OpenCyphal-ToF-Distance-Sensor-Node.ino
@@ -19,6 +19,7 @@
 #include <107-Arduino-Cyphal.h>
 #include <107-Arduino-MCP2515.h>
 #include <107-Arduino-TMF8801.h>
+#include <107-Arduino-UniqueId.h>
 #define DBG_ENABLE_ERROR
 #define DBG_ENABLE_WARNING
 #define DBG_ENABLE_INFO

--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Communication
 url=https://github.com/107-systems/107-Arduino-Cyphal
 architectures=samd,mbed,mbed_nano,mbed_portenta,mbed_edge,esp32,rp2040
 includes=107-Arduino-Cyphal.h
-depends=107-Arduino-UniqueId
+depends=

--- a/src/107-Arduino-Cyphal.h
+++ b/src/107-Arduino-Cyphal.h
@@ -12,8 +12,6 @@
  * INCLUDE
  **************************************************************************************/
 
-#include <107-Arduino-UniqueId.h>
-
 #include "Node.hpp"
 #include "Types.h"
 #include "nodeinfo/NodeInfo.h"


### PR DESCRIPTION
It's sufficient to include it into those sketches where you want to use it.