### PR TITLE
Replace dynamic memory allocation inside receive buffer with static memory allocation.

### DIFF
--- a/examples/OpenCyphal-Blink/OpenCyphal-Blink.ino
+++ b/examples/OpenCyphal-Blink/OpenCyphal-Blink.ino
@@ -64,7 +64,9 @@ ArduinoMCP2515 mcp2515([]() { digitalWrite(MKRCAN_MCP2515_CS_PIN, LOW); },
                        nullptr);
 
 Node::Heap<Node::DEFAULT_O1HEAP_SIZE> node_heap;
-Node node_hdl(node_heap.data(), node_heap.size(), micros);
+CircularBuffer<Node::TReceiveCircularBuffer>::Heap<Node::DEFAULT_RX_QUEUE_SIZE> node_rx_queue;
+Node node_hdl(node_heap.data(), node_heap.size(), node_rx_queue.data(), node_rx_queue.size(), micros);
+
 Publisher<Heartbeat_1_0<>> heartbeat_pub = node_hdl.create_publisher<Heartbeat_1_0<>>(
   Heartbeat_1_0<>::PORT_ID, 1*1000*1000UL /* = 1 sec in usecs. */);
 auto heartbeat_subscription = node_hdl.create_subscription<Bit_1_0<BIT_PORT_ID>>(

--- a/examples/OpenCyphal-GNSS-Node/OpenCyphal-GNSS-Node.ino
+++ b/examples/OpenCyphal-GNSS-Node/OpenCyphal-GNSS-Node.ino
@@ -101,7 +101,9 @@ ArduinoMCP2515 mcp2515([]() { digitalWrite(MKRCAN_MCP2515_CS_PIN, LOW); },
                        nullptr);
 
 Node::Heap<Node::DEFAULT_O1HEAP_SIZE> node_heap;
-Node node_hdl(node_heap.data(), node_heap.size(), micros);
+CircularBuffer<Node::TReceiveCircularBuffer>::Heap<Node::DEFAULT_RX_QUEUE_SIZE> node_rx_queue;
+Node node_hdl(node_heap.data(), node_heap.size(), node_rx_queue.data(), node_rx_queue.size(), micros);
+
 Publisher<uavcan::node::Heartbeat_1_0<>> heartbeat_pub = node_hdl.create_publisher<uavcan::node::Heartbeat_1_0<>>(uavcan::node::Heartbeat_1_0<>::PORT_ID, 1*1000*1000UL /* = 1 sec in usecs. */);
 
 ArduinoNmeaParser nmea_parser(gnss::onRmcUpdate, gnss::onGgaUpdate);

--- a/examples/OpenCyphal-Heartbeat-Publisher/OpenCyphal-Heartbeat-Publisher.ino
+++ b/examples/OpenCyphal-Heartbeat-Publisher/OpenCyphal-Heartbeat-Publisher.ino
@@ -40,7 +40,9 @@ ArduinoMCP2515 mcp2515([]() { digitalWrite(MKRCAN_MCP2515_CS_PIN, LOW); },
                        nullptr);
 
 Node::Heap<Node::DEFAULT_O1HEAP_SIZE> node_heap;
-Node node_hdl(node_heap.data(), node_heap.size(), micros);
+CircularBuffer<Node::TReceiveCircularBuffer>::Heap<Node::DEFAULT_RX_QUEUE_SIZE> node_rx_queue;
+Node node_hdl(node_heap.data(), node_heap.size(), node_rx_queue.data(), node_rx_queue.size(), micros);
+
 Publisher<Heartbeat_1_0<>> heartbeat_pub = node_hdl.create_publisher<Heartbeat_1_0<>>(Heartbeat_1_0<>::PORT_ID, 1*1000*1000UL /* = 1 sec in usecs. */);
 
 Heartbeat_1_0<> hb_msg;

--- a/examples/OpenCyphal-Heartbeat-Subscriber/OpenCyphal-Heartbeat-Subscriber.ino
+++ b/examples/OpenCyphal-Heartbeat-Subscriber/OpenCyphal-Heartbeat-Subscriber.ino
@@ -48,7 +48,9 @@ ArduinoMCP2515 mcp2515([]() { digitalWrite(MKRCAN_MCP2515_CS_PIN, LOW); },
                        nullptr);
 
 Node::Heap<Node::DEFAULT_O1HEAP_SIZE> node_heap;
-Node node_hdl(node_heap.data(), node_heap.size(), micros);
+CircularBuffer<Node::TReceiveCircularBuffer>::Heap<Node::DEFAULT_RX_QUEUE_SIZE> node_rx_queue;
+Node node_hdl(node_heap.data(), node_heap.size(), node_rx_queue.data(), node_rx_queue.size(), micros);
+
 Subscription heartbeat_subscription =
   node_hdl.create_subscription<Heartbeat_1_0<>>(Heartbeat_1_0<>::PORT_ID, CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC, onHeartbeat_1_0_Received);
 

--- a/examples/OpenCyphal-Service-Client/OpenCyphal-Service-Client.ino
+++ b/examples/OpenCyphal-Service-Client/OpenCyphal-Service-Client.ino
@@ -49,7 +49,8 @@ ArduinoMCP2515 mcp2515([]() { digitalWrite(MKRCAN_MCP2515_CS_PIN, LOW); },
                        nullptr);
 
 Node::Heap<Node::DEFAULT_O1HEAP_SIZE> node_heap;
-Node node_hdl(node_heap.data(), node_heap.size(), micros);
+CircularBuffer<Node::TReceiveCircularBuffer>::Heap<Node::DEFAULT_RX_QUEUE_SIZE> node_rx_queue;
+Node node_hdl(node_heap.data(), node_heap.size(), node_rx_queue.data(), node_rx_queue.size(), micros);
 
 /**************************************************************************************
  * SETUP/LOOP

--- a/examples/OpenCyphal-Service-Server/OpenCyphal-Service-Server.ino
+++ b/examples/OpenCyphal-Service-Server/OpenCyphal-Service-Server.ino
@@ -49,7 +49,9 @@ ArduinoMCP2515 mcp2515([]() { digitalWrite(MKRCAN_MCP2515_CS_PIN, LOW); },
                        nullptr);
 
 Node::Heap<Node::DEFAULT_O1HEAP_SIZE> node_heap;
-Node node_hdl(node_heap.data(), node_heap.size(), micros);
+CircularBuffer<Node::TReceiveCircularBuffer>::Heap<Node::DEFAULT_RX_QUEUE_SIZE> node_rx_queue;
+Node node_hdl(node_heap.data(), node_heap.size(), node_rx_queue.data(), node_rx_queue.size(), micros);
+
 Service execute_command_srv = node_hdl.create_service<ExecuteCommand_1_0::Request<>, ExecuteCommand_1_0::Response<>>(
   ExecuteCommand_1_0::Request<>::PORT_ID,
   2*1000*1000UL,

--- a/examples/OpenCyphal-ToF-Distance-Sensor-Node/OpenCyphal-ToF-Distance-Sensor-Node.ino
+++ b/examples/OpenCyphal-ToF-Distance-Sensor-Node/OpenCyphal-ToF-Distance-Sensor-Node.ino
@@ -123,7 +123,9 @@ ArduinoMCP2515 mcp2515([]()
                        nullptr);
 
 Node::Heap<Node::DEFAULT_O1HEAP_SIZE> node_heap;
-Node node_hdl(node_heap.data(), node_heap.size(), micros, OPEN_CYPHAL_NODE_ID);
+CircularBuffer<Node::TReceiveCircularBuffer>::Heap<Node::DEFAULT_RX_QUEUE_SIZE> node_rx_queue;
+Node node_hdl(node_heap.data(), node_heap.size(), node_rx_queue.data(), node_rx_queue.size(), micros, OPEN_CYPHAL_NODE_ID);
+
 Publisher<Heartbeat_1_0<>> heartbeat_pub = node_hdl.create_publisher<Heartbeat_1_0<>>(Heartbeat_1_0<>::PORT_ID, 1*1000*1000UL /* = 1 sec in usecs. */);
 Publisher<DistanceMessageType> tof_pub = node_hdl.create_publisher<DistanceMessageType>(OPEN_CYPHAL_ID_DISTANCE_DATA, 1*1000*1000UL /* = 1 sec in usecs. */);
 

--- a/src/CircularBuffer.hpp
+++ b/src/CircularBuffer.hpp
@@ -9,83 +9,49 @@
 #define ARDUINO_CYPHAL_UTILITY_RINGBUFFER_H_
 
 /**************************************************************************************
- * NAMESPACE
+ * INCLUDE
  **************************************************************************************/
 
-namespace opencyphal
-{
+#include <cstdlib>
+
+#include <array>
 
 /**************************************************************************************
  * CLASS DECLARATION
  **************************************************************************************/
 
-template <class T>
-class RingBuffer
+template <typename T>
+class CircularBuffer
 {
 public:
-  RingBuffer(size_t const size)
-  : _buffer{new T[size]}
-  , _size{size}
-  , _head{0}
-  , _tail{0}
-  , _num_elems{0}
-  { }
+  template <size_t SIZE>
+  struct Heap final : public std::array<T, SIZE> {};
 
-  ~RingBuffer()
-  {
-    delete[] _buffer;
-    _size = 0;
-    _head = 0;
-    _tail = 0;
-    _num_elems = 0;
-  }
 
-  void enqueue(T const & val)
-  {
-    if (isFull()) return;
-    _buffer[_head] = val;
-    _head = nextIndex(_head);
-    _num_elems++;
-  }
+   CircularBuffer(T * heap_ptr, size_t const heap_size);
+  ~CircularBuffer();
 
-  T dequeue()
-  {
-    if (isEmpty()) return T{};
-    T const val = _buffer[_tail];
-    _tail = nextIndex(_tail);
-    _num_elems--;
-    return val;
-  }
 
-  size_t available() const
-  {
-    return _num_elems;
-  }
+  void enqueue(T const & val);
+  T dequeue();
 
-  bool isFull() const
-  {
-    return (_num_elems == _size);
-  }
 
-  bool isEmpty() const
-  {
-    return (_num_elems == 0);
-  }
+  size_t available() const { return _num_elems; }
+  bool isFull() const { return (_num_elems == _size); }
+  bool isEmpty() const { return (_num_elems == 0); }
+
 
 private:
   T * _buffer;
   size_t _size, _head, _tail, _num_elems;
 
-  size_t nextIndex(size_t const index)
-  {
-    return ((index + 1) % _size);
-  }
+  size_t nextIndex(size_t const index) { return ((index + 1) % _size); }
 };
 
 /**************************************************************************************
- * NAMESPACE
+ * TEMPLATE IMPLEMENTATION
  **************************************************************************************/
 
-} /* opencyphal */
+#include "CircularBuffer.ipp"
 
 #endif /* ARDUINO_CYPHAL_UTILITY_RINGBUFFER_H_ */

--- a/src/CircularBuffer.ipp
+++ b/src/CircularBuffer.ipp
@@ -1,0 +1,55 @@
+/**
+ * This software is distributed under the terms of the MIT License.
+ * Copyright (c) 2020-2023 LXRobotics.
+ * Author: Alexander Entinger <alexander.entinger@lxrobotics.com>
+ * Contributors: https://github.com/107-systems/107-Arduino-Cyphal/graphs/contributors.
+ */
+
+/**************************************************************************************
+ * CTOR/DTOR
+ **************************************************************************************/
+
+template <typename T>
+CircularBuffer<T>::CircularBuffer(T * heap_ptr, size_t const heap_size)
+: _buffer{heap_ptr}
+, _size{heap_size}
+, _head{0}
+, _tail{0}
+, _num_elems{0}
+{
+
+}
+
+template <typename T>
+CircularBuffer<T>::~CircularBuffer()
+{
+  _size = 0;
+  _head = 0;
+  _tail = 0;
+  _num_elems = 0;
+}
+
+/**************************************************************************************
+ * PUBLIC MEMBER FUNCTIONS
+ **************************************************************************************/
+
+template <typename T>
+void CircularBuffer<T>::enqueue(T const & val)
+{
+  if (isFull()) return;
+
+  _buffer[_head] = val;
+  _head = nextIndex(_head);
+  _num_elems++;
+}
+
+template <typename T>
+T CircularBuffer<T>::dequeue()
+{
+  if (isEmpty()) return T{};
+
+  T const val = _buffer[_tail];
+  _tail = nextIndex(_tail);
+  _num_elems--;
+  return val;
+}

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -19,16 +19,17 @@
 
 Node::Node(uint8_t * heap_ptr,
            size_t const heap_size,
+           TReceiveCircularBuffer * rx_queue_heap_ptr,
+           size_t const rx_queue_heap_size,
            MicrosFunc const micros_func,
            CanardNodeID const node_id,
            size_t const tx_queue_capacity,
-           size_t const rx_queue_capacity,
            size_t const mtu_bytes)
 : _o1heap_ins{o1heapInit(heap_ptr, heap_size)}
 , _canard_hdl{canardInit(Node::o1heap_allocate, Node::o1heap_free)}
 , _micros_func{micros_func}
 , _canard_tx_queue{canardTxInit(tx_queue_capacity, mtu_bytes)}
-, _canard_rx_queue{rx_queue_capacity}
+, _canard_rx_queue{rx_queue_heap_ptr, rx_queue_heap_size}
 {
   _canard_hdl.node_id = node_id;
   _canard_hdl.user_reference = static_cast<void *>(_o1heap_ins);


### PR DESCRIPTION
Doing so allows the compiler to report memory usage during compilation time.