### PR TITLE
Fix: Drop if clause since subscrition callback is a native lambda and not a function pointer.

### DIFF
--- a/src/Subscription.ipp
+++ b/src/Subscription.ipp
@@ -30,8 +30,7 @@ bool Subscription<T, OnReceiveCb>::onTransferReceived(CanardRxTransfer const & t
 {
   T const msg = T::deserialize(transfer);
 
-  if (_on_receive_cb)
-    _on_receive_cb(msg);
+  _on_receive_cb(msg);
 
   return true;
 }


### PR DESCRIPTION
Keeping this line in also leads to compile errors when subscribing to a lambda function.