### PR TITLE
Configure "Compile Examples" workflow for authenticated API requests.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -79,6 +79,7 @@ jobs:
           platforms: ${{ matrix.board.platforms }}
           libraries: ${{ env.LIBRARIES }}
           enable-deltas-report: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Save memory usage change report as artifact


### PR DESCRIPTION
[The arduino/compile-sketches GitHub Actions action](https://github.com/arduino/compile-sketches) used in the "Compile Examples" [workflow](https://docs.github.com/actions/using-workflows/about-workflows) queries [the GitHub API](https://docs.github.com/en/rest) for the base ref of the pull request, which is used for the [memory deltas determination](https://github.com/arduino/compile-sketches#enable-deltas-report).

GitHub does [rate limiting of API requests](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting) and if the limit is exceeded, a spurious failure of the workflow run will occur, as was happening previously ([example](https://github.com/SpenceKonde/megaTinyCore/actions/runs/3858167935)).

Authenticated API requests are given a more generous API request allowance, so providing the action with [the automatically generated GitHub access token stored in secrets.GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) to use for the API requests should prevent any further workflow run failures caused by rate limiting.