### PR TITLE
Allow to override transfer-ID timeout when creating a new subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,7 @@ void loop() {
 Node::Heap<Node::DEFAULT_O1HEAP_SIZE> node_heap;
 Node node_hdl(node_heap.data(), node_heap.size(), micros, [] (CanardFrame const & frame) { /* ... */ });
 
-Subscription heartbeat_subscription = node_hdl.create_subscription<Heartbeat_1_0>
-  (CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC, onHeartbeat_1_0_Received);
+Subscription heartbeat_subscription = node_hdl.create_subscription<Heartbeat_1_0>(onHeartbeat_1_0_Received);
 /* ... */
 void loop() {
   /* Process all pending OpenCyphal actions. */

--- a/examples/OpenCyphal-Blink/OpenCyphal-Blink.ino
+++ b/examples/OpenCyphal-Blink/OpenCyphal-Blink.ino
@@ -65,7 +65,7 @@ Node node_hdl(node_heap.data(), node_heap.size(), micros, [] (CanardFrame const 
 Publisher<Heartbeat_1_0> heartbeat_pub = node_hdl.create_publisher<Heartbeat_1_0>
   (1*1000*1000UL /* = 1 sec in usecs. */);
 Subscription bit_subscription = node_hdl.create_subscription<Bit_1_0>
-  (BIT_PORT_ID, CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC, onBit_1_0_Received);
+  (BIT_PORT_ID, onBit_1_0_Received);
 
 /**************************************************************************************
  * SETUP/LOOP

--- a/examples/OpenCyphal-Heartbeat-Subscriber/OpenCyphal-Heartbeat-Subscriber.ino
+++ b/examples/OpenCyphal-Heartbeat-Subscriber/OpenCyphal-Heartbeat-Subscriber.ino
@@ -50,8 +50,7 @@ ArduinoMCP2515 mcp2515([]() { digitalWrite(MKRCAN_MCP2515_CS_PIN, LOW); },
 Node::Heap<Node::DEFAULT_O1HEAP_SIZE> node_heap;
 Node node_hdl(node_heap.data(), node_heap.size(), micros, [] (CanardFrame const & frame) { return mcp2515.transmit(frame); });
 
-Subscription heartbeat_subscription = node_hdl.create_subscription<Heartbeat_1_0>
-  (CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC, onHeartbeat_1_0_Received);
+Subscription heartbeat_subscription = node_hdl.create_subscription<Heartbeat_1_0>(onHeartbeat_1_0_Received);
 
 /**************************************************************************************
  * SETUP/LOOP

--- a/src/Node.hpp
+++ b/src/Node.hpp
@@ -85,14 +85,14 @@ public:
   Subscription create_subscription(CanardPortID const port_id, OnReceiveCb&& on_receive_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
 
   template <typename T_REQ, typename T_RSP, typename OnRequestCb>
-  ServiceServer create_service_server(CanardMicrosecond const tx_timeout_usec, OnRequestCb&& on_request_cb);
+  ServiceServer create_service_server(CanardMicrosecond const tx_timeout_usec, OnRequestCb&& on_request_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
   template <typename T_REQ, typename T_RSP, typename OnRequestCb>
-  ServiceServer create_service_server(CanardPortID const request_port_id, CanardMicrosecond const tx_timeout_usec, OnRequestCb&& on_request_cb);
+  ServiceServer create_service_server(CanardPortID const request_port_id, CanardMicrosecond const tx_timeout_usec, OnRequestCb&& on_request_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
 
   template <typename T_REQ, typename T_RSP, typename OnResponseCb>
-  ServiceClient<T_REQ> create_service_client(CanardMicrosecond const tx_timeout_usec, OnResponseCb&& on_response_cb);
+  ServiceClient<T_REQ> create_service_client(CanardMicrosecond const tx_timeout_usec, OnResponseCb&& on_response_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
   template <typename T_REQ, typename T_RSP, typename OnResponseCb>
-  ServiceClient<T_REQ> create_service_client(CanardPortID const response_port_id, CanardMicrosecond const tx_timeout_usec, OnResponseCb&& on_response_cb);
+  ServiceClient<T_REQ> create_service_client(CanardPortID const response_port_id, CanardMicrosecond const tx_timeout_usec, OnResponseCb&& on_response_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
 
 #if __GNUC__ >= 11
   Registry create_registry();

--- a/src/Node.hpp
+++ b/src/Node.hpp
@@ -80,9 +80,9 @@ public:
   Publisher<T> create_publisher(CanardPortID const port_id, CanardMicrosecond const tx_timeout_usec);
 
   template <typename T, typename OnReceiveCb>
-  Subscription create_subscription(CanardMicrosecond const rx_timeout_usec, OnReceiveCb&& on_receive_cb);
+  Subscription create_subscription(OnReceiveCb&& on_receive_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
   template <typename T, typename OnReceiveCb>
-  Subscription create_subscription(CanardPortID const port_id, CanardMicrosecond const rx_timeout_usec, OnReceiveCb&& on_receive_cb);
+  Subscription create_subscription(CanardPortID const port_id, OnReceiveCb&& on_receive_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
 
   template <typename T_REQ, typename T_RSP, typename OnRequestCb>
   ServiceServer create_service_server(CanardMicrosecond const tx_timeout_usec, OnRequestCb&& on_request_cb);

--- a/src/Node.ipp
+++ b/src/Node.ipp
@@ -68,16 +68,16 @@ Subscription Node::create_subscription(CanardPortID const port_id, OnReceiveCb&&
 }
 
 template <typename T_REQ, typename T_RSP, typename OnRequestCb>
-ServiceServer Node::create_service_server(CanardMicrosecond const tx_timeout_usec, OnRequestCb&& on_request_cb)
+ServiceServer Node::create_service_server(CanardMicrosecond const tx_timeout_usec, OnRequestCb&& on_request_cb, CanardMicrosecond const tid_timeout_usec)
 {
   static_assert(T_REQ::_traits_::HasFixedPortID, "T_REQ does not have a fixed port id.");
   static_assert(T_RSP::_traits_::HasFixedPortID, "T_RSP does not have a fixed port id.");
 
-  return create_service_server<T_REQ, T_RSP>(T_REQ::_traits_::FixedPortId, tx_timeout_usec, on_request_cb);
+  return create_service_server<T_REQ, T_RSP>(T_REQ::_traits_::FixedPortId, tx_timeout_usec, on_request_cb, tid_timeout_usec);
 }
 
 template <typename T_REQ, typename T_RSP, typename OnRequestCb>
-ServiceServer Node::create_service_server(CanardPortID const request_port_id, CanardMicrosecond const tx_timeout_usec, OnRequestCb&& on_request_cb)
+ServiceServer Node::create_service_server(CanardPortID const request_port_id, CanardMicrosecond const tx_timeout_usec, OnRequestCb&& on_request_cb, CanardMicrosecond const tid_timeout_usec)
 {
   static_assert(T_REQ::_traits_::IsRequest, "T_REQ is not a request");
   static_assert(T_RSP::_traits_::IsResponse, "T_RSP is not a response");
@@ -93,7 +93,7 @@ ServiceServer Node::create_service_server(CanardPortID const request_port_id, Ca
                                       CanardTransferKindRequest,
                                       request_port_id,
                                       T_REQ::_traits_::ExtentBytes,
-                                      CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC,
+                                      tid_timeout_usec,
                                       &(srv->canard_rx_subscription()));
   if (rc < 0)
     return nullptr;
@@ -102,16 +102,16 @@ ServiceServer Node::create_service_server(CanardPortID const request_port_id, Ca
 }
 
 template <typename T_REQ, typename T_RSP, typename OnResponseCb>
-ServiceClient<T_REQ> Node::create_service_client(CanardMicrosecond const tx_timeout_usec, OnResponseCb&& on_response_cb)
+ServiceClient<T_REQ> Node::create_service_client(CanardMicrosecond const tx_timeout_usec, OnResponseCb&& on_response_cb, CanardMicrosecond const tid_timeout_usec)
 {
   static_assert(T_REQ::_traits_::HasFixedPortID, "T_REQ does not have a fixed port id.");
   static_assert(T_RSP::_traits_::HasFixedPortID, "T_RSP does not have a fixed port id.");
 
-  return create_service_client<T_REQ, T_RSP>(T_RSP::_traits_::FixedPortId, tx_timeout_usec, on_response_cb);
+  return create_service_client<T_REQ, T_RSP>(T_RSP::_traits_::FixedPortId, tx_timeout_usec, on_response_cb, tid_timeout_usec);
 }
 
 template <typename T_REQ, typename T_RSP, typename OnResponseCb>
-ServiceClient<T_REQ> Node::create_service_client(CanardPortID const response_port_id, CanardMicrosecond const tx_timeout_usec, OnResponseCb&& on_response_cb)
+ServiceClient<T_REQ> Node::create_service_client(CanardPortID const response_port_id, CanardMicrosecond const tx_timeout_usec, OnResponseCb&& on_response_cb, CanardMicrosecond const tid_timeout_usec)
 {
   static_assert(T_REQ::_traits_::IsRequest, "T_REQ is not a request");
   static_assert(T_RSP::_traits_::IsResponse, "T_RSP is not a response");
@@ -127,7 +127,7 @@ ServiceClient<T_REQ> Node::create_service_client(CanardPortID const response_por
                                       CanardTransferKindResponse,
                                       response_port_id,
                                       T_RSP::_traits_::ExtentBytes,
-                                      CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC,
+                                      tid_timeout_usec,
                                       &(clt->canard_rx_subscription()));
   if (rc < 0)
     return nullptr;

--- a/src/Node.ipp
+++ b/src/Node.ipp
@@ -38,14 +38,14 @@ Publisher<T> Node::create_publisher(CanardPortID const port_id, CanardMicrosecon
 }
 
 template <typename T, typename OnReceiveCb>
-Subscription Node::create_subscription(CanardMicrosecond const rx_timeout_usec, OnReceiveCb&& on_receive_cb)
+Subscription Node::create_subscription(OnReceiveCb&& on_receive_cb, CanardMicrosecond const tid_timeout_usec)
 {
   static_assert(T::_traits_::HasFixedPortID, "T does not have a fixed port id.");
-  return create_subscription<T>(T::_traits_::FixedPortId, rx_timeout_usec, on_receive_cb);
+  return create_subscription<T>(T::_traits_::FixedPortId, on_receive_cb, tid_timeout_usec);
 }
 
 template <typename T, typename OnReceiveCb>
-Subscription Node::create_subscription(CanardPortID const port_id, CanardMicrosecond const rx_timeout_usec, OnReceiveCb&& on_receive_cb)
+Subscription Node::create_subscription(CanardPortID const port_id, OnReceiveCb&& on_receive_cb, CanardMicrosecond const tid_timeout_usec)
 {
   static_assert(!T::_traits_::IsServiceType, "T is not message type");
 
@@ -59,7 +59,7 @@ Subscription Node::create_subscription(CanardPortID const port_id, CanardMicrose
                                       CanardTransferKindMessage,
                                       port_id,
                                       T::_traits_::ExtentBytes,
-                                      rx_timeout_usec,
+                                      tid_timeout_usec,
                                       &(sub->canard_rx_subscription()));
   if (rc < 0)
     return nullptr;


### PR DESCRIPTION
This fixes #188.