### PR TITLE
No default init of max message buffer.

### DIFF
--- a/src/Publisher.ipp
+++ b/src/Publisher.ipp
@@ -42,7 +42,7 @@ bool Publisher<T>::publish(T const & msg)
 #pragma GCC diagnostic pop
 
   /* Serialize message into payload buffer. */
-  std::array<uint8_t, T::_traits_::SerializationBufferSizeBytes> msg_buf{};
+  std::array<uint8_t, T::_traits_::SerializationBufferSizeBytes> msg_buf;
   nunavut::support::bitspan msg_buf_bitspan{msg_buf};
   auto const rc = serialize(msg, msg_buf_bitspan);
   if (!rc) return false;

--- a/src/ServiceClient.ipp
+++ b/src/ServiceClient.ipp
@@ -51,7 +51,7 @@ bool ServiceClient<T_REQ, T_RSP, OnResponseCb>::request(CanardNodeID const remot
 #pragma GCC diagnostic pop
 
   /* Serialize message into payload buffer. */
-  std::array<uint8_t, T_REQ::_traits_::SerializationBufferSizeBytes> req_buf{};
+  std::array<uint8_t, T_REQ::_traits_::SerializationBufferSizeBytes> req_buf;
   nunavut::support::bitspan req_buf_bitspan{req_buf};
   auto const req_rc = serialize(req, req_buf_bitspan);
   if (!req_rc) return false;

--- a/src/ServiceServer.ipp
+++ b/src/ServiceServer.ipp
@@ -46,7 +46,7 @@ bool ServiceServer<T_REQ, T_RSP, OnRequestCb>::onTransferReceived(CanardRxTransf
   T_RSP const rsp = _on_request_cb(req);
 
   /* Serialize the response message. */
-  std::array<uint8_t, T_RSP::_traits_::SerializationBufferSizeBytes> rsp_buf{};
+  std::array<uint8_t, T_RSP::_traits_::SerializationBufferSizeBytes> rsp_buf;
   nunavut::support::bitspan rsp_buf_bitspan{rsp_buf};
   auto const rsp_rc = serialize(rsp, rsp_buf_bitspan);
   if (!rsp_rc) return false;


### PR DESCRIPTION
This is not necessary and can take a long time on a MCU.