### PR TITLE
Fix: always create port/List.1.0 publisher.

### DIFF
--- a/examples/host-example-01-opencyphal-basic-node/host-example-01-opencyphal-basic-node.cpp
+++ b/examples/host-example-01-opencyphal-basic-node/host-example-01-opencyphal-basic-node.cpp
@@ -58,8 +58,6 @@ int main(int argc, char ** argv)
   Node node_hdl(node_heap.data(), node_heap.size(), micros, [socket_can_fd] (CanardFrame const & frame) { return (socketcanPush(socket_can_fd, &frame, 1000*1000UL) > 0); });
   std::mutex node_mtx;
 
-  PortListPublisher port_list_pub = node_hdl.create_port_list_publisher();
-
   Publisher<uavcan::node::Heartbeat_1_0> heartbeat_pub = node_hdl.create_publisher<uavcan::node::Heartbeat_1_0>
     (1*1000*1000UL /* = 1 sec in usecs. */);
 

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -40,17 +40,13 @@ Node::Node(uint8_t * heap_ptr,
 {
   _canard_hdl.node_id = node_id;
   _canard_hdl.user_reference = static_cast<void *>(_o1heap_ins);
+
+  _opt_port_list_pub = std::make_shared<impl::PortListPublisher>(*this, _micros_func);
 }
 
 /**************************************************************************************
  * PUBLIC MEMBER FUNCTIONS
  **************************************************************************************/
-
-PortListPublisher Node::create_port_list_publisher()
-{
-  _opt_port_list_pub = std::make_shared<impl::PortListPublisher>(*this, _micros_func);
-  return _opt_port_list_pub.value();
-}
 
 #if __GNUC__ >= 11
 Registry Node::create_registry()

--- a/src/Node.hpp
+++ b/src/Node.hpp
@@ -76,9 +76,6 @@ public:
   inline CanardNodeID getNodeId() const { return _canard_hdl.node_id; }
 
 
-  PortListPublisher create_port_list_publisher();
-
-
   template <typename T>
   Publisher<T> create_publisher(CanardMicrosecond const tx_timeout_usec);
   template <typename T>


### PR DESCRIPTION
If Publishers/Subscriptions/etc. are created as global static objects the order of initialisation is not clear. Hence it could happen that Publisher IDs are not probably registered.