### PR TITLE
Fix/service examples

### DIFF
--- a/examples/OpenCyphal-Service-Server/OpenCyphal-Service-Server.ino
+++ b/examples/OpenCyphal-Service-Server/OpenCyphal-Service-Server.ino
@@ -49,7 +49,7 @@ ArduinoMCP2515 mcp2515([]() { digitalWrite(MKRCAN_MCP2515_CS_PIN, LOW); },
                        nullptr);
 
 Node::Heap<Node::DEFAULT_O1HEAP_SIZE> node_heap;
-Node node_hdl(node_heap.data(), node_heap.size(), micros, [] (CanardFrame const & frame) { return mcp2515.transmit(frame); });
+Node node_hdl(node_heap.data(), node_heap.size(), micros, [] (CanardFrame const & frame) { return mcp2515.transmit(frame); }, 27);
 
 ServiceServer execute_command_srv = node_hdl.create_service_server<ExecuteCommand::Request_1_1, ExecuteCommand::Response_1_1>(
   2*1000*1000UL,
@@ -63,9 +63,12 @@ void setup()
 {
   Serial.begin(9600);
   while(!Serial) { }
+  delay(1000);
+  Serial.println("|---- OpenCyphal Service Server Example ----|");
 
   /* Setup SPI access */
   SPI.begin();
+
   pinMode(MKRCAN_MCP2515_CS_PIN, OUTPUT);
   digitalWrite(MKRCAN_MCP2515_CS_PIN, HIGH);
 
@@ -77,6 +80,8 @@ void setup()
   mcp2515.begin();
   mcp2515.setBitRate(CanBitRate::BR_250kBPS_16MHZ);
   mcp2515.setNormalMode();
+
+  Serial.println("setup finished");
 }
 
 void loop()
@@ -101,6 +106,19 @@ void onReceiveBufferFull(CanardFrame const & frame)
 ExecuteCommand::Response_1_1 onExecuteCommand_1_1_Request_Received(ExecuteCommand::Request_1_1 const & req)
 {
   ExecuteCommand::Response_1_1 rsp;
+  Serial.println("Coffee has been requested");
+
+  std::string parameter;
+
+  std::copy(
+    req.parameter.begin(),
+    req.parameter.end(),
+    std::back_inserter(parameter));
+
+  for (uint8_t i = 0; i < parameter.size(); i++) {
+    Serial.print(parameter[i]);
+  }
+  Serial.println("");
 
   if (req.command == 0xCAFE)
     rsp.status = ExecuteCommand::Response_1_1::STATUS_SUCCESS;


### PR DESCRIPTION
This PR fixes the Service Client example when filling the parameter variable when sending an ExecuteCommand_1_1 by changing it from std::copy_n to std::copy and also back filling with std::back_insertor.

 I also added a bit of code to the Service Server example so it prints the contents of the parameter variable on receipt on an ExecuteCommand_1_1 request.

I added some other serial prints so aid in debugging and know which example is running on which device, along with node ids.

![service_parameter_working](https://github.com/107-systems/107-Arduino-Cyphal/assets/74357249/dbfed727-f4bf-4efb-8edd-26ce1c46e37d)

Picture to show it working on my setup