### PR TITLE
[Feature] Allow passing of function pointer for feeding the watchdog during lengthy file IO operations.

### DIFF
--- a/src/util/storage/register_storage.hpp
+++ b/src/util/storage/register_storage.hpp
@@ -24,10 +24,16 @@ namespace cyphal::support
 /// The serialization format is simply the Cyphal DSDL.
 /// In case of error, only part of the registers may be loaded and the registry will be left in an inconsistent state.
 [[nodiscard]] inline std::optional<platform::storage::Error> load(const platform::storage::interface::KeyValueStorage& kv,
-                                                                  registry::IIntrospectableRegistry&  rgy)
+                                                                  registry::IIntrospectableRegistry&  rgy,
+                                                                  std::function<void()> const feed_watchdog_func)
 {
     for (std::size_t index = 0; index < rgy.size(); index++)
     {
+        // Prevent timeout during slow persistent storage IO access
+        if (feed_watchdog_func) {
+          feed_watchdog_func();
+        }
+
         // Find the next register in the registry.
         const auto reg_name_storage = rgy.index(index);  // This is a little suboptimal but we don't care.
         const auto reg_name = std::string_view(reinterpret_cast<const char *>(reg_name_storage.name.cbegin()), reg_name_storage.name.size());
@@ -67,6 +73,11 @@ namespace cyphal::support
     }
     return std::nullopt;
 }
+[[nodiscard]] inline std::optional<platform::storage::Error> load(const platform::storage::interface::KeyValueStorage& kv,
+                                                                  registry::IIntrospectableRegistry&  rgy)
+{
+  return load(kv, rgy, nullptr);
+}
 
 /// The register savior is the counterpart of load().
 /// Saves all persistent mutable registers from the registry to the storage.
@@ -84,10 +95,16 @@ namespace cyphal::support
 template <typename ResetPredicate>
 [[nodiscard]] std::optional<platform::storage::Error> save(platform::storage::interface::KeyValueStorage&            kv,
                                                            const registry::IIntrospectableRegistry& rgy,
+                                                           std::function<void()> const feed_watchdog_func,
                                                            ResetPredicate const reset_predicate)
 {
     for (std::size_t index = 0; index < rgy.size(); index++)
     {
+        // Prevent timeout during slow persistent storage IO access
+        if (feed_watchdog_func) {
+          feed_watchdog_func();
+        }
+
         const auto reg_name_storage = rgy.index(index);  // This is a little suboptimal but we don't care.
         const auto reg_name = std::string_view(reinterpret_cast<const char *>(reg_name_storage.name.cbegin()), reg_name_storage.name.size());
         if (reg_name.empty())
@@ -127,10 +144,17 @@ template <typename ResetPredicate>
     }
     return std::nullopt;
 }
-[[nodiscard]] inline std::optional<platform::storage::Error> save(platform::storage::interface::KeyValueStorage&            kv,
+template <typename ResetPredicate>
+[[nodiscard]] std::optional<platform::storage::Error> save(platform::storage::interface::KeyValueStorage& kv,
+                                                           const registry::IIntrospectableRegistry& rgy,
+                                                           std::function<void()> const feed_watchdog_func)
+{
+    return save(kv, rgy, feed_watchdog_func, [](std::string_view) { return false; });
+}
+[[nodiscard]] inline std::optional<platform::storage::Error> save(platform::storage::interface::KeyValueStorage& kv,
                                                                   const registry::IIntrospectableRegistry& rgy)
 {
-    return save(kv, rgy, [](std::string_view) { return false; });
+    return save(kv, rgy, nullptr, [](std::string_view) { return false; });
 }
 
 } /* namespace cyphal::support */

--- a/src/util/storage/register_storage.hpp
+++ b/src/util/storage/register_storage.hpp
@@ -23,9 +23,10 @@ namespace cyphal::support
 /// Stored registers that are not present in the registry will not be loaded.
 /// The serialization format is simply the Cyphal DSDL.
 /// In case of error, only part of the registers may be loaded and the registry will be left in an inconsistent state.
-[[nodiscard]] inline std::optional<platform::storage::Error> load(const platform::storage::interface::KeyValueStorage& kv,
-                                                                  registry::IIntrospectableRegistry&  rgy,
-                                                                  std::function<void()> const feed_watchdog_func)
+[[nodiscard]] inline std::optional<platform::storage::Error> load(
+  const platform::storage::interface::KeyValueStorage & kv,
+  registry::IIntrospectableRegistry & rgy,
+  std::function<void()> const feed_watchdog_func)
 {
     for (std::size_t index = 0; index < rgy.size(); index++)
     {
@@ -73,8 +74,10 @@ namespace cyphal::support
     }
     return std::nullopt;
 }
-[[nodiscard]] inline std::optional<platform::storage::Error> load(const platform::storage::interface::KeyValueStorage& kv,
-                                                                  registry::IIntrospectableRegistry&  rgy)
+
+[[nodiscard]] inline std::optional<platform::storage::Error> load(
+  const platform::storage::interface::KeyValueStorage & kv,
+  registry::IIntrospectableRegistry & rgy)
 {
   return load(kv, rgy, nullptr);
 }
@@ -93,10 +96,11 @@ namespace cyphal::support
 /// The removal predicate, if provided, allows the caller to specify which registers need to be removed from the
 /// storage instead of being saved. This is useful for implementing the "factory reset" feature.
 template <typename ResetPredicate>
-[[nodiscard]] std::optional<platform::storage::Error> save(platform::storage::interface::KeyValueStorage&            kv,
-                                                           const registry::IIntrospectableRegistry& rgy,
-                                                           std::function<void()> const feed_watchdog_func,
-                                                           ResetPredicate const reset_predicate)
+[[nodiscard]] inline std::optional<platform::storage::Error> save(
+  platform::storage::interface::KeyValueStorage & kv,
+  const registry::IIntrospectableRegistry & rgy,
+  std::function<void()> const feed_watchdog_func,
+  ResetPredicate const reset_predicate)
 {
     for (std::size_t index = 0; index < rgy.size(); index++)
     {
@@ -144,19 +148,22 @@ template <typename ResetPredicate>
     }
     return std::nullopt;
 }
-template <typename ResetPredicate>
-[[nodiscard]] std::optional<platform::storage::Error> save(platform::storage::interface::KeyValueStorage& kv,
-                                                           const registry::IIntrospectableRegistry& rgy,
-                                                           std::function<void()> const feed_watchdog_func)
+
+[[nodiscard]] inline std::optional<platform::storage::Error> save(
+  platform::storage::interface::KeyValueStorage & kv,
+  const registry::IIntrospectableRegistry & rgy,
+  std::function<void()> const feed_watchdog_func)
 {
     return save(kv, rgy, feed_watchdog_func, [](std::string_view) { return false; });
 }
-[[nodiscard]] inline std::optional<platform::storage::Error> save(platform::storage::interface::KeyValueStorage& kv,
-                                                                  const registry::IIntrospectableRegistry& rgy)
+
+[[nodiscard]] inline std::optional<platform::storage::Error> save(
+  platform::storage::interface::KeyValueStorage & kv,
+  const registry::IIntrospectableRegistry & rgy)
 {
     return save(kv, rgy, nullptr, [](std::string_view) { return false; });
 }
 
-} /* namespace cyphal::support */
+} /* cyphal::support */
 
 #endif /* !defined(__GNUC__) || (__GNUC__ >= 11) */


### PR DESCRIPTION
This prevents the watchdog from biting and resetting the application before all values have been loaded from/stored to the persistent storage medium.

This fixes #233.