### PR TITLE
Add returning Metadata to subscription callback

### DIFF
--- a/examples/OpenCyphal-Heartbeat-Subscriber-With-Metadata/OpenCyphal-Heartbeat-Subscriber-With-Metadata.ino
+++ b/examples/OpenCyphal-Heartbeat-Subscriber-With-Metadata/OpenCyphal-Heartbeat-Subscriber-With-Metadata.ino
@@ -26,13 +26,9 @@ using namespace uavcan::node;
  * CONSTANTS
  **************************************************************************************/
 
-static int const MKRCAN_MCP2515_CS_PIN  = 21;
-static int const MKRCAN_MCP2515_INT_PIN = 22;
-#define SPI_ROBOT_INT 22
-#define SPI_ROBOT_CS 21
-#define SPI_ROBOT_MISO 16
-#define SPI_ROBOT_MOSI 19
-#define SPI_ROBOT_SCK 18
+static int const MKRCAN_MCP2515_CS_PIN  = 3;
+static int const MKRCAN_MCP2515_INT_PIN = 7;
+
 /**************************************************************************************
  * FUNCTION DECLARATION
  **************************************************************************************/
@@ -52,7 +48,7 @@ ArduinoMCP2515 mcp2515([]() { digitalWrite(MKRCAN_MCP2515_CS_PIN, LOW); },
                        nullptr);
 
 Node::Heap<Node::DEFAULT_O1HEAP_SIZE> node_heap;
-Node node_hdl(node_heap.data(), node_heap.size(), micros, [] (CanardFrame const & frame) { return mcp2515.transmit(frame); }, 22);
+Node node_hdl(node_heap.data(), node_heap.size(), micros, [] (CanardFrame const & frame) { return mcp2515.transmit(frame); });
 
 Subscription heartbeat_subscription = node_hdl.create_subscription<Heartbeat_1_0>(onHeartbeat_1_0_Received);
 /**************************************************************************************
@@ -67,21 +63,17 @@ void setup()
   Serial.println("|---- OpenCyphal Heartbeat Subscription With Metadata  Example ----|");
 
   /* Setup SPI access */
-  SPI.setRX(SPI_ROBOT_MISO);
-  SPI.setTX(SPI_ROBOT_MOSI);
-  SPI.setSCK(SPI_ROBOT_SCK);
-  SPI.setCS(SPI_ROBOT_CS);
   SPI.begin();
   pinMode(MKRCAN_MCP2515_CS_PIN, OUTPUT);
   digitalWrite(MKRCAN_MCP2515_CS_PIN, HIGH);
 
   /* Attach interrupt handler to register MCP2515 signaled by taking INT low */
   pinMode(MKRCAN_MCP2515_INT_PIN, INPUT_PULLUP);
-  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, FALLING);
+  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, LOW);
 
   /* Initialize MCP2515 */
   mcp2515.begin();
-  mcp2515.setBitRate(CanBitRate::BR_1000kBPS_16MHZ);
+  mcp2515.setBitRate(CanBitRate::BR_250kBPS_16MHZ);
   mcp2515.setNormalMode();
 
   Serial.println("setup finished");

--- a/examples/OpenCyphal-Heartbeat-Subscriber-With-Metadata/OpenCyphal-Heartbeat-Subscriber-With-Metadata.ino
+++ b/examples/OpenCyphal-Heartbeat-Subscriber-With-Metadata/OpenCyphal-Heartbeat-Subscriber-With-Metadata.ino
@@ -64,7 +64,7 @@ void setup()
   Serial.begin(9600);
   while(!Serial) { }
   delay(1000);
-  Serial.println("|---- OpenCyphal Heartbeat Subscription Example ----|");
+  Serial.println("|---- OpenCyphal Heartbeat Subscription With Metadata  Example ----|");
 
   /* Setup SPI access */
   SPI.setRX(SPI_ROBOT_MISO);

--- a/examples/OpenCyphal-Heartbeat-Subscriber/OpenCyphal-Heartbeat-Subscriber.ino
+++ b/examples/OpenCyphal-Heartbeat-Subscriber/OpenCyphal-Heartbeat-Subscriber.ino
@@ -51,6 +51,7 @@ Node::Heap<Node::DEFAULT_O1HEAP_SIZE> node_heap;
 Node node_hdl(node_heap.data(), node_heap.size(), micros, [] (CanardFrame const & frame) { return mcp2515.transmit(frame); });
 
 Subscription heartbeat_subscription = node_hdl.create_subscription<Heartbeat_1_0>(onHeartbeat_1_0_Received);
+
 /**************************************************************************************
  * SETUP/LOOP
  **************************************************************************************/
@@ -69,7 +70,7 @@ void setup()
 
   /* Attach interrupt handler to register MCP2515 signaled by taking INT low */
   pinMode(MKRCAN_MCP2515_INT_PIN, INPUT_PULLUP);
-  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, FALLING);
+  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, LOW);
 
   /* Initialize MCP2515 */
   mcp2515.begin();

--- a/examples/OpenCyphal-Heartbeat-Subscriber/OpenCyphal-Heartbeat-Subscriber.ino
+++ b/examples/OpenCyphal-Heartbeat-Subscriber/OpenCyphal-Heartbeat-Subscriber.ino
@@ -26,15 +26,20 @@ using namespace uavcan::node;
  * CONSTANTS
  **************************************************************************************/
 
-static int const MKRCAN_MCP2515_CS_PIN  = 3;
-static int const MKRCAN_MCP2515_INT_PIN = 7;
-
+static int const MKRCAN_MCP2515_CS_PIN  = 21;
+static int const MKRCAN_MCP2515_INT_PIN = 22;
+#define SPI_ROBOT_INT 22
+#define SPI_ROBOT_CS 21
+#define SPI_ROBOT_MISO 16
+#define SPI_ROBOT_MOSI 19
+#define SPI_ROBOT_SCK 18
 /**************************************************************************************
  * FUNCTION DECLARATION
  **************************************************************************************/
 
 void onReceiveBufferFull    (CanardFrame const &);
 void onHeartbeat_1_0_Received(Heartbeat_1_0 const & msg);
+void onHeartbeat_1_0_Received_meta(Heartbeat_1_0 const & msg, TransferMetadata const & metadata);
 
 /**************************************************************************************
  * GLOBAL VARIABLES
@@ -48,10 +53,10 @@ ArduinoMCP2515 mcp2515([]() { digitalWrite(MKRCAN_MCP2515_CS_PIN, LOW); },
                        nullptr);
 
 Node::Heap<Node::DEFAULT_O1HEAP_SIZE> node_heap;
-Node node_hdl(node_heap.data(), node_heap.size(), micros, [] (CanardFrame const & frame) { return mcp2515.transmit(frame); });
+Node node_hdl(node_heap.data(), node_heap.size(), micros, [] (CanardFrame const & frame) { return mcp2515.transmit(frame); }, 22);
 
-Subscription heartbeat_subscription = node_hdl.create_subscription<Heartbeat_1_0>(onHeartbeat_1_0_Received);
-
+// Subscription heartbeat_subscription = node_hdl.create_subscription<Heartbeat_1_0>(onHeartbeat_1_0_Received);
+Subscription heartbeat_subscription = node_hdl.create_subscription<Heartbeat_1_0>(onHeartbeat_1_0_Received_meta);
 /**************************************************************************************
  * SETUP/LOOP
  **************************************************************************************/
@@ -60,20 +65,28 @@ void setup()
 {
   Serial.begin(9600);
   while(!Serial) { }
+  delay(1000);
+  Serial.println("|---- OpenCyphal Heartbeat Subscription Example ----|");
 
   /* Setup SPI access */
+  SPI.setRX(SPI_ROBOT_MISO);
+  SPI.setTX(SPI_ROBOT_MOSI);
+  SPI.setSCK(SPI_ROBOT_SCK);
+  SPI.setCS(SPI_ROBOT_CS);
   SPI.begin();
   pinMode(MKRCAN_MCP2515_CS_PIN, OUTPUT);
   digitalWrite(MKRCAN_MCP2515_CS_PIN, HIGH);
 
   /* Attach interrupt handler to register MCP2515 signaled by taking INT low */
   pinMode(MKRCAN_MCP2515_INT_PIN, INPUT_PULLUP);
-  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, LOW);
+  attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), []() { mcp2515.onExternalEventHandler(); }, FALLING);
 
   /* Initialize MCP2515 */
   mcp2515.begin();
-  mcp2515.setBitRate(CanBitRate::BR_250kBPS_16MHZ);
+  mcp2515.setBitRate(CanBitRate::BR_1000kBPS_16MHZ);
   mcp2515.setNormalMode();
+
+  Serial.println("setup finished");
 }
 
 void loop()
@@ -103,4 +116,15 @@ void onHeartbeat_1_0_Received(Heartbeat_1_0 const & msg)
            msg.uptime, msg.health.value, msg.mode.value, msg.vendor_specific_status_code);
 
   Serial.println(msg_buf);
+}
+
+void onHeartbeat_1_0_Received_meta(Heartbeat_1_0 const & msg, TransferMetadata const & metadata)
+{
+  char msg_buf[64];
+  snprintf(msg_buf, sizeof(msg_buf),
+           "Uptime = %d, Health = %d, Mode = %d, VSSC = %d",
+           msg.uptime, msg.health.value, msg.mode.value, msg.vendor_specific_status_code);
+
+  Serial.println(msg_buf);
+  Serial.println(metadata.node_id, HEX);
 }

--- a/examples/OpenCyphal-Heartbeat-Subscriber/OpenCyphal-Heartbeat-Subscriber.ino
+++ b/examples/OpenCyphal-Heartbeat-Subscriber/OpenCyphal-Heartbeat-Subscriber.ino
@@ -26,13 +26,9 @@ using namespace uavcan::node;
  * CONSTANTS
  **************************************************************************************/
 
-static int const MKRCAN_MCP2515_CS_PIN  = 21;
-static int const MKRCAN_MCP2515_INT_PIN = 22;
-#define SPI_ROBOT_INT 22
-#define SPI_ROBOT_CS 21
-#define SPI_ROBOT_MISO 16
-#define SPI_ROBOT_MOSI 19
-#define SPI_ROBOT_SCK 18
+static int const MKRCAN_MCP2515_CS_PIN  = 3;
+static int const MKRCAN_MCP2515_INT_PIN = 7;
+
 /**************************************************************************************
  * FUNCTION DECLARATION
  **************************************************************************************/
@@ -52,7 +48,7 @@ ArduinoMCP2515 mcp2515([]() { digitalWrite(MKRCAN_MCP2515_CS_PIN, LOW); },
                        nullptr);
 
 Node::Heap<Node::DEFAULT_O1HEAP_SIZE> node_heap;
-Node node_hdl(node_heap.data(), node_heap.size(), micros, [] (CanardFrame const & frame) { return mcp2515.transmit(frame); }, 22);
+Node node_hdl(node_heap.data(), node_heap.size(), micros, [] (CanardFrame const & frame) { return mcp2515.transmit(frame); });
 
 Subscription heartbeat_subscription = node_hdl.create_subscription<Heartbeat_1_0>(onHeartbeat_1_0_Received);
 /**************************************************************************************
@@ -67,10 +63,6 @@ void setup()
   Serial.println("|---- OpenCyphal Heartbeat Subscription Example ----|");
 
   /* Setup SPI access */
-  SPI.setRX(SPI_ROBOT_MISO);
-  SPI.setTX(SPI_ROBOT_MOSI);
-  SPI.setSCK(SPI_ROBOT_SCK);
-  SPI.setCS(SPI_ROBOT_CS);
   SPI.begin();
   pinMode(MKRCAN_MCP2515_CS_PIN, OUTPUT);
   digitalWrite(MKRCAN_MCP2515_CS_PIN, HIGH);
@@ -81,7 +73,7 @@ void setup()
 
   /* Initialize MCP2515 */
   mcp2515.begin();
-  mcp2515.setBitRate(CanBitRate::BR_1000kBPS_16MHZ);
+  mcp2515.setBitRate(CanBitRate::BR_250kBPS_16MHZ);
   mcp2515.setNormalMode();
 
   Serial.println("setup finished");

--- a/examples/OpenCyphal-Heartbeat-Subscriber/OpenCyphal-Heartbeat-Subscriber.ino
+++ b/examples/OpenCyphal-Heartbeat-Subscriber/OpenCyphal-Heartbeat-Subscriber.ino
@@ -39,7 +39,6 @@ static int const MKRCAN_MCP2515_INT_PIN = 22;
 
 void onReceiveBufferFull    (CanardFrame const &);
 void onHeartbeat_1_0_Received(Heartbeat_1_0 const & msg);
-void onHeartbeat_1_0_Received_meta(Heartbeat_1_0 const & msg, TransferMetadata const & metadata);
 
 /**************************************************************************************
  * GLOBAL VARIABLES
@@ -55,8 +54,7 @@ ArduinoMCP2515 mcp2515([]() { digitalWrite(MKRCAN_MCP2515_CS_PIN, LOW); },
 Node::Heap<Node::DEFAULT_O1HEAP_SIZE> node_heap;
 Node node_hdl(node_heap.data(), node_heap.size(), micros, [] (CanardFrame const & frame) { return mcp2515.transmit(frame); }, 22);
 
-// Subscription heartbeat_subscription = node_hdl.create_subscription<Heartbeat_1_0>(onHeartbeat_1_0_Received);
-Subscription heartbeat_subscription = node_hdl.create_subscription<Heartbeat_1_0>(onHeartbeat_1_0_Received_meta);
+Subscription heartbeat_subscription = node_hdl.create_subscription<Heartbeat_1_0>(onHeartbeat_1_0_Received);
 /**************************************************************************************
  * SETUP/LOOP
  **************************************************************************************/
@@ -116,15 +114,4 @@ void onHeartbeat_1_0_Received(Heartbeat_1_0 const & msg)
            msg.uptime, msg.health.value, msg.mode.value, msg.vendor_specific_status_code);
 
   Serial.println(msg_buf);
-}
-
-void onHeartbeat_1_0_Received_meta(Heartbeat_1_0 const & msg, TransferMetadata const & metadata)
-{
-  char msg_buf[64];
-  snprintf(msg_buf, sizeof(msg_buf),
-           "Uptime = %d, Health = %d, Mode = %d, VSSC = %d",
-           msg.uptime, msg.health.value, msg.mode.value, msg.vendor_specific_status_code);
-
-  Serial.println(msg_buf);
-  Serial.println(metadata.node_id, HEX);
 }

--- a/src/Node.hpp
+++ b/src/Node.hpp
@@ -30,6 +30,7 @@
 #include "util/nodeinfo/NodeInfoBase.hpp"
 #include "util/registry/registry_impl.hpp"
 #include "util/port/PortListPublisherBase.hpp"
+#include "util/transfer_metadata.hpp"
 
 #include "libo1heap/o1heap.h"
 #include "libcanard/canard.h"
@@ -37,11 +38,6 @@
 /**************************************************************************************
  * CLASS DECLARATION
  **************************************************************************************/
-struct TransferMetadata final
-{
-    CanardNodeID node_id;
-    // More stuff may appear here in the future!
-};
 
 class Node
 {

--- a/src/Node.hpp
+++ b/src/Node.hpp
@@ -37,6 +37,11 @@
 /**************************************************************************************
  * CLASS DECLARATION
  **************************************************************************************/
+struct TransferMetadata final
+{
+    CanardNodeID node_id;
+    // More stuff may appear here in the future!
+};
 
 class Node
 {
@@ -81,10 +86,15 @@ public:
   template <typename T>
   Publisher<T> create_publisher(CanardPortID const port_id, CanardMicrosecond const tx_timeout_usec);
 
-  template <typename T, typename OnReceiveCb>
-  Subscription create_subscription(OnReceiveCb&& on_receive_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
-  template <typename T, typename OnReceiveCb>
-  Subscription create_subscription(CanardPortID const port_id, OnReceiveCb&& on_receive_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
+  template <typename T>
+  Subscription create_subscription(std::function<void(T const &)>&& on_receive_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
+  template <typename T>
+  Subscription create_subscription(CanardPortID const port_id, std::function<void(T const &)>&& on_receive_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
+
+  template <typename T>
+  Subscription create_subscription(std::function<void(T const &, TransferMetadata const &)>&& on_receive_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
+  template <typename T>
+  Subscription create_subscription(CanardPortID const port_id, std::function<void(T const &, TransferMetadata const &)>&& on_receive_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
 
   template <typename T_REQ, typename T_RSP, typename OnRequestCb>
   ServiceServer create_service_server(CanardMicrosecond const tx_timeout_usec, OnRequestCb&& on_request_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);

--- a/src/Node.ipp
+++ b/src/Node.ipp
@@ -40,25 +40,58 @@ Publisher<T> Node::create_publisher(CanardPortID const port_id, CanardMicrosecon
     );
 }
 
-template <typename T, typename OnReceiveCb>
-Subscription Node::create_subscription(OnReceiveCb&& on_receive_cb, CanardMicrosecond const tid_timeout_usec)
+template <typename T>
+Subscription Node::create_subscription(std::function<void(T const &)>&& on_receive_cb, CanardMicrosecond const tid_timeout_usec)
 {
   static_assert(T::_traits_::HasFixedPortID, "T does not have a fixed port id.");
-  return create_subscription<T>(T::_traits_::FixedPortId, on_receive_cb, tid_timeout_usec);
+  return create_subscription<T>(T::_traits_::FixedPortId, std::forward<std::function<void(T const &)>>(on_receive_cb), tid_timeout_usec);
 }
 
-template <typename T, typename OnReceiveCb>
-Subscription Node::create_subscription(CanardPortID const port_id, OnReceiveCb&& on_receive_cb, CanardMicrosecond const tid_timeout_usec)
+template <typename T>
+Subscription Node::create_subscription(CanardPortID const port_id, std::function<void(T const &)>&& on_receive_cb, CanardMicrosecond const tid_timeout_usec)
 {
   static_assert(!T::_traits_::IsServiceType, "T is not message type");
 
   if (_opt_port_list_pub.has_value())
     _opt_port_list_pub.value()->add_subscriber(port_id);
 
-  auto sub = std::make_shared<impl::Subscription<T, OnReceiveCb>>(
+  auto sub = std::make_shared<impl::Subscription<T>>(
     *this,
     port_id,
-    std::forward<OnReceiveCb>(on_receive_cb)
+    std::forward<std::function<void(T const &)>>(on_receive_cb)
+    );
+
+  int8_t const rc = canardRxSubscribe(&_canard_hdl,
+                                      CanardTransferKindMessage,
+                                      port_id,
+                                      T::_traits_::ExtentBytes,
+                                      tid_timeout_usec,
+                                      &(sub->canard_rx_subscription()));
+  if (rc < 0)
+    return nullptr;
+
+  return sub;
+}
+
+template <typename T>
+Subscription Node::create_subscription(std::function<void(T const &, TransferMetadata const &)>&& on_receive_cb, CanardMicrosecond const tid_timeout_usec)
+{
+  static_assert(T::_traits_::HasFixedPortID, "T does not have a fixed port id.");
+  return create_subscription<T>(T::_traits_::FixedPortId, std::forward<std::function<void(T const &, TransferMetadata const &)>>(on_receive_cb), tid_timeout_usec);
+}
+
+template <typename T>
+Subscription Node::create_subscription(CanardPortID const port_id, std::function<void(T const &, TransferMetadata const &)>&& on_receive_cb, CanardMicrosecond const tid_timeout_usec)
+{
+  static_assert(!T::_traits_::IsServiceType, "T is not message type");
+
+  if (_opt_port_list_pub.has_value())
+    _opt_port_list_pub.value()->add_subscriber(port_id);
+
+  auto sub = std::make_shared<impl::Subscription<T>>(
+    *this,
+    port_id,
+    std::forward<std::function<void(T const &, TransferMetadata const &)>>(on_receive_cb)
     );
 
   int8_t const rc = canardRxSubscribe(&_canard_hdl,

--- a/src/Subscription.hpp
+++ b/src/Subscription.hpp
@@ -60,7 +60,7 @@ public:
   , _on_receive_cb_ext{on_receive_cb_ext}
   {
     return_metadata = true;
-   }
+  }
   virtual ~Subscription();
 
 

--- a/src/Subscription.hpp
+++ b/src/Subscription.hpp
@@ -15,6 +15,7 @@
 #include "SubscriptionBase.h"
 
 #include "Node.hpp"
+#include "util/transfer_metadata.hpp"
 
 
 /**************************************************************************************

--- a/src/Subscription.hpp
+++ b/src/Subscription.hpp
@@ -16,6 +16,7 @@
 
 #include "Node.hpp"
 
+
 /**************************************************************************************
  * NAMESPACE
  **************************************************************************************/
@@ -23,20 +24,42 @@
 namespace impl
 {
 
+// #if LIBCANARD
+// #define CanardNodeID CyphalNodeID;
+// #elif LIBUDPARD
+// #define UdpardNodeID CyphalNodeID;
+// #else
+// # error "We only support CAN or UDP as Cyphal transport layer"
+// #endif
+
+
 /**************************************************************************************
  * CLASS DECLARATION
  **************************************************************************************/
 
-template <typename T, typename OnReceiveCb>
+template <typename T>
+
 class Subscription final : public SubscriptionBase
 {
+
 public:
-  Subscription(Node & node_hdl, CanardPortID const port_id, OnReceiveCb const & on_receive_cb)
+  using OnReceiveCallback_Default= std::function<void(T const &)>;
+  using OnReceiveCallback_Ext = std::function<void(T const &, TransferMetadata const &)>;
+  Subscription(Node & node_hdl, CanardPortID const port_id, OnReceiveCallback_Default const & on_receive_cb)
   : SubscriptionBase{CanardTransferKindMessage}
   , _node_hdl{node_hdl}
   , _port_id{port_id}
   , _on_receive_cb{on_receive_cb}
   { }
+
+  Subscription(Node & node_hdl, CanardPortID const port_id, OnReceiveCallback_Ext const & on_receive_cb_ext)
+  : SubscriptionBase{CanardTransferKindMessage}
+  , _node_hdl{node_hdl}
+  , _port_id{port_id}
+  , _on_receive_cb_ext{on_receive_cb_ext}
+  {
+    output_meta = true;
+   }
   virtual ~Subscription();
 
 
@@ -46,7 +69,9 @@ public:
 private:
   Node & _node_hdl;
   CanardPortID const _port_id;
-  OnReceiveCb _on_receive_cb;
+  OnReceiveCallback_Default _on_receive_cb;
+  OnReceiveCallback_Ext _on_receive_cb_ext;
+  bool output_meta = false;
 };
 
 /**************************************************************************************

--- a/src/Subscription.hpp
+++ b/src/Subscription.hpp
@@ -39,7 +39,6 @@ namespace impl
  **************************************************************************************/
 
 template <typename T>
-
 class Subscription final : public SubscriptionBase
 {
 

--- a/src/Subscription.hpp
+++ b/src/Subscription.hpp
@@ -58,7 +58,7 @@ public:
   , _port_id{port_id}
   , _on_receive_cb_ext{on_receive_cb_ext}
   {
-    output_meta = true;
+    return_metadata = true;
    }
   virtual ~Subscription();
 
@@ -71,7 +71,9 @@ private:
   CanardPortID const _port_id;
   OnReceiveCallback_Default _on_receive_cb;
   OnReceiveCallback_Ext _on_receive_cb_ext;
-  bool output_meta = false;
+  bool return_metadata = false;
+
+  TransferMetadata fillMetadata(CanardRxTransfer const & transfer);
 };
 
 /**************************************************************************************

--- a/src/Subscription.hpp
+++ b/src/Subscription.hpp
@@ -25,15 +25,6 @@
 namespace impl
 {
 
-// #if LIBCANARD
-// #define CanardNodeID CyphalNodeID;
-// #elif LIBUDPARD
-// #define UdpardNodeID CyphalNodeID;
-// #else
-// # error "We only support CAN or UDP as Cyphal transport layer"
-// #endif
-
-
 /**************************************************************************************
  * CLASS DECLARATION
  **************************************************************************************/

--- a/src/Subscription.ipp
+++ b/src/Subscription.ipp
@@ -41,10 +41,8 @@ bool Subscription<T>::onTransferReceived(CanardRxTransfer const & transfer)
   auto const rc = deserialize(msg, msg_bitspan);
   if (!rc) return false;
 
-  if(output_meta) {
-    TransferMetadata meta_data;
-    meta_data.node_id = static_cast<uint16_t>(transfer.metadata.remote_node_id);
-    _on_receive_cb_ext(msg, meta_data);
+  if(return_metadata) {
+    _on_receive_cb_ext(msg, fillMetadata(transfer));
   } else {
     _on_receive_cb(msg);
   }
@@ -53,6 +51,14 @@ bool Subscription<T>::onTransferReceived(CanardRxTransfer const & transfer)
   return true;
 }
 
+template<typename T>
+TransferMetadata Subscription<T>::fillMetadata(CanardRxTransfer const & transfer)
+{
+  TransferMetadata transfer_metadata;
+  transfer_metadata.node_id = static_cast<uint16_t>(transfer.metadata.remote_node_id);
+
+  return transfer_metadata;
+}
 /**************************************************************************************
  * NAMESPACE
  **************************************************************************************/

--- a/src/Subscription.ipp
+++ b/src/Subscription.ipp
@@ -23,8 +23,8 @@ namespace impl {
  * CTOR/DTOR
  **************************************************************************************/
 
-template<typename T, typename OnReceiveCb>
-Subscription<T, OnReceiveCb>::~Subscription()
+template<typename T>
+Subscription<T>::~Subscription()
 {
   _node_hdl.unsubscribe(_port_id, SubscriptionBase::canard_transfer_kind());
 }
@@ -33,15 +33,22 @@ Subscription<T, OnReceiveCb>::~Subscription()
  * PUBLIC MEMBER FUNCTIONS
  **************************************************************************************/
 
-template<typename T, typename OnReceiveCb>
-bool Subscription<T, OnReceiveCb>::onTransferReceived(CanardRxTransfer const & transfer)
+template<typename T>
+bool Subscription<T>::onTransferReceived(CanardRxTransfer const & transfer)
 {
   T msg;
   nunavut::support::const_bitspan msg_bitspan(static_cast<uint8_t *>(transfer.payload), transfer.payload_size);
   auto const rc = deserialize(msg, msg_bitspan);
   if (!rc) return false;
 
-  _on_receive_cb(msg);
+  if(output_meta) {
+    TransferMetadata meta_data;
+    meta_data.node_id = static_cast<uint16_t>(transfer.metadata.remote_node_id);
+    _on_receive_cb_ext(msg, meta_data);
+  } else {
+    _on_receive_cb(msg);
+  }
+
 
   return true;
 }

--- a/src/util/transfer_metadata.hpp
+++ b/src/util/transfer_metadata.hpp
@@ -1,3 +1,9 @@
+/**
+ * This software is distributed under the terms of the MIT License.
+ * Copyright (c) 2020-2023 LXRobotics.
+ * Author: Alexander Entinger <alexander.entinger@lxrobotics.com>
+ * Contributors: https://github.com/107-systems/107-Arduino-Cyphal/graphs/contributors.
+ */
 
 #ifndef ARDUINO_CYPHAL_TRANSFER_METADATA_HPP_
 #define ARDUINO_CYPHAL_TRANSFER_METADATA_HPP_

--- a/src/util/transfer_metadata.hpp
+++ b/src/util/transfer_metadata.hpp
@@ -1,0 +1,21 @@
+
+#ifndef ARDUINO_CYPHAL_TRANSFER_METADATA_HPP_
+#define ARDUINO_CYPHAL_TRANSFER_METADATA_HPP_
+
+#if defined __has_include
+#  if __has_include (<libcanard/canard.h>)
+  using CyphalNodeID = CanardNodeID;
+#  elif __has_include (<lipudpard/udpard.h>)
+  using CyphalNodeID = UdpardNodeID;
+#  endif
+#else
+# error "We only support CAN or UDP as Cyphal transport layer"
+#endif
+
+struct TransferMetadata final
+{
+  CyphalNodeID node_id;
+  // More stuff may appear here in the future!
+};
+
+#endif // ARDUINO_CYPHAL_TRANSFER_METADATA_HPP_


### PR DESCRIPTION
This PR adds in the functionality described #232.

I've added another example showing how to use the extended API.

Some screenshots of both the original subscription working and the extended API working.
![subscription_original](https://github.com/107-systems/107-Arduino-Cyphal/assets/74357249/9dfd5b8a-a529-4e0b-ac48-371de0e2c8bb)
![subscription_with_meta_data](https://github.com/107-systems/107-Arduino-Cyphal/assets/74357249/9441f218-969a-4d7a-9747-30d9f2055a3c)

Note: I only have experience wih using libcanard and this library, so haven't tested the functionality with libudpard.

