### PR TITLE
Fix: overload 'get' in order to enable std::string as supported parameters.

### DIFF
--- a/src/util/registry/registry_value.hpp
+++ b/src/util/registry/registry_value.hpp
@@ -211,6 +211,11 @@ inline void set(Value& dst, const std::string& string)
 {
   set(dst, std::string_view(string));
 }
+/// Assigns string to the value, truncating if necessary.
+inline void set(Value& dst, const char* const string)
+{
+  set(dst, std::string_view(string));
+}
 /// Assigns numerical arrays/vectors of various arithmetic types to the value.
 /// E.g., passing an std::array<float, 7> here will switch the value to real32[7].
 /// The existing contents of the value is discarded.

--- a/src/util/registry/registry_value.hpp
+++ b/src/util/registry/registry_value.hpp
@@ -170,6 +170,15 @@ template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
     }
     return false;
 }
+[[nodiscard]] inline bool get(const Value& src, std::string& dst)
+{
+  if (const auto* const str = src.get_string_if())
+  {
+    dst = std::string{reinterpret_cast<const char*>(str->value.data()), str->value.size()};
+    return true;
+  }
+  return false;
+}
 }  // namespace detail
 
 /// Convert the value stored in source to the same type and dimensionality as destination; update destination in-place.

--- a/src/util/registry/registry_value.hpp
+++ b/src/util/registry/registry_value.hpp
@@ -206,6 +206,11 @@ inline void set(Value& dst, const std::string_view string)
         str.value.push_back(static_cast<std::uint8_t>(string[i]));
     }
 }
+/// Assigns string to the value, truncating if necessary.
+inline void set(Value& dst, const std::string& string)
+{
+  set(dst, std::string_view(string));
+}
 /// Assigns numerical arrays/vectors of various arithmetic types to the value.
 /// E.g., passing an std::array<float, 7> here will switch the value to real32[7].
 /// The existing contents of the value is discarded.


### PR DESCRIPTION
As suggest by @pavel-kirienko over [here](https://github.com/107-systems/OpenCyphalPicoBase-firmware/pull/40#issuecomment-1621470792).

Unfortunately leads to a really ugly error message ...

```bash
In file included from /home/alex/Arduino/libraries/107-Arduino-Cyphal/src/util/nodeinfo/../../types/uavcan/node/port/ID_1_0.hpp:51,
                 from /home/alex/Arduino/libraries/107-Arduino-Cyphal/src/util/nodeinfo/../../DSDL_Types.h.impl:11,
                 from /home/alex/Arduino/libraries/107-Arduino-Cyphal/src/util/nodeinfo/../../DSDL_Types.h:20,
                 from /home/alex/Arduino/libraries/107-Arduino-Cyphal/src/util/nodeinfo/NodeInfoBase.hpp:17,
                 from /home/alex/Arduino/libraries/107-Arduino-Cyphal/src/Node.hpp:30,
                 from /home/alex/Arduino/libraries/107-Arduino-Cyphal/src/107-Arduino-Cyphal.h:15,
                 from /home/alex/projects/107-systems/OpenCyphalPicoBase-firmware/OpenCyphalPicoBase-firmware.ino:18:
/home/alex/.arduino15/packages/rp2040/tools/pqt-gcc/1.5.0-a-5007782/arm-none-eabi/include/c++/12.2.0/variant: In substitution of 'template<unsigned int _Np, class ... _Args> std::enable_if_t<(!(_Np < 15)), void> std::variant<uavcan::primitive::Empty_1_0, uavcan::primitive::String_1_0, uavcan::primitive::Unstructured_1_0, uavcan::primitive::array::Bit_1_0, uavcan::primitive::array::Integer64_1_0, uavcan::primitive::array::Integer32_1_0, uavcan::primitive::array::Integer16_1_0, uavcan::primitive::array::Integer8_1_0, uavcan::primitive::array::Natural64_1_0, uavcan::primitive::array::Natural32_1_0, uavcan::primitive::array::Natural16_1_0, uavcan::primitive::array::Natural8_1_0, uavcan::primitive::array::Real64_1_0, uavcan::primitive::array::Real32_1_0, uavcan::primitive::array::Real16_1_0>::emplace(_Args&& ...) [with unsigned int _Np = 896; _Args = <missing>]':
/home/alex/Arduino/libraries/107-Arduino-Cyphal/src/util/registry/registry_value.hpp:96:67:   recursively required from 'constexpr const std::size_t registry::detail::ArraySelector<char, 1, void>::Index'
/home/alex/Arduino/libraries/107-Arduino-Cyphal/src/util/registry/registry_value.hpp:96:67:   required from 'constexpr const std::size_t registry::detail::ArraySelector<char, 0, void>::Index'
/home/alex/Arduino/libraries/107-Arduino-Cyphal/src/util/registry/registry_value.hpp:214:57:   required by substitution of 'template<class Container, class T, unsigned int Index> void registry::set(Value&, const Container&) [with Container = std::__cxx11::basic_string<char>; T = char; unsigned int Index = <missing>]'
/home/alex/Arduino/libraries/107-Arduino-Cyphal/src/util/registry/registry_impl.hpp:326:26:   required from 'registry::ValueWithMetadata registry::Registry::Reg<N, G, S, IsMutable>::get() const [with N = std::basic_string_view<char>; G = registry::Registry::expose<const char (&)[24], std::__cxx11::basic_string<char> >(const char (&)[24], const Options&, std::__cxx11::basic_string<char>&)::<lambda()>; S = registry::Registry::expose<const char (&)[24], std::__cxx11::basic_string<char> >(const char (&)[24], const Options&, std::__cxx11::basic_string<char>&)::<lambda(const registry::Value&)>; bool IsMutable = true]'
/home/alex/Arduino/libraries/107-Arduino-Cyphal/src/util/registry/registry_impl.hpp:323:41:   required from here
/home/alex/.arduino15/packages/rp2040/tools/pqt-gcc/1.5.0-a-5007782/arm-none-eabi/include/c++/12.2.0/variant:1586:49: fatal error: template instantiation depth exceeds maximum of 900 (use '-ftemplate-depth=' to increase the maximum)
 1586 |         enable_if_t<!(_Np < sizeof...(_Types))> emplace(_Args&&...) = delete;
      |                                                 ^~~~~~~
compilation terminated.
```

CC @generationmake 