### PR TITLE
Remove documentation references to obsolete hardware.

### DIFF
--- a/examples/OpenCyphal-Blink/OpenCyphal-Blink.ino
+++ b/examples/OpenCyphal-Blink/OpenCyphal-Blink.ino
@@ -7,10 +7,6 @@
  *
  * switch built in LED off with
  *   yakut -i 'CAN(can.media.socketcan.SocketCANMedia("can0",8),59)' pub 1620.uavcan.primitive.scalar.Bit.1.0 'value: false'
- *
- * Hardware:
- *   - Arduino MKR family board, e.g. MKR VIDOR 4000
- *   - Arduino MKR CAN shield
  */
 
 /**************************************************************************************

--- a/examples/OpenCyphal-Heartbeat-Publisher/OpenCyphal-Heartbeat-Publisher.ino
+++ b/examples/OpenCyphal-Heartbeat-Publisher/OpenCyphal-Heartbeat-Publisher.ino
@@ -1,9 +1,5 @@
 /*
  * This example shows periodic transmission of a OpenCyphal heartbeat message via CAN.
- *
- * Hardware:
- *   - Arduino MKR family board, e.g. MKR VIDOR 4000
- *   - Arduino MKR CAN shield
  */
 
 /**************************************************************************************

--- a/examples/OpenCyphal-Heartbeat-Subscriber-With-Metadata/OpenCyphal-Heartbeat-Subscriber-With-Metadata.ino
+++ b/examples/OpenCyphal-Heartbeat-Subscriber-With-Metadata/OpenCyphal-Heartbeat-Subscriber-With-Metadata.ino
@@ -1,9 +1,5 @@
 /*
  * This example shows reception of a OpenCyphal heartbeat message via CAN.
- *
- * Hardware:
- *   - Arduino MKR family board, e.g. MKR VIDOR 4000
- *   - Arduino MKR CAN shield
  */
 
 /**************************************************************************************

--- a/examples/OpenCyphal-Heartbeat-Subscriber/OpenCyphal-Heartbeat-Subscriber.ino
+++ b/examples/OpenCyphal-Heartbeat-Subscriber/OpenCyphal-Heartbeat-Subscriber.ino
@@ -1,9 +1,5 @@
 /*
  * This example shows reception of a OpenCyphal heartbeat message via CAN.
- *
- * Hardware:
- *   - Arduino MKR family board, e.g. MKR VIDOR 4000
- *   - Arduino MKR CAN shield
  */
 
 /**************************************************************************************

--- a/examples/OpenCyphal-Service-Client/OpenCyphal-Service-Client.ino
+++ b/examples/OpenCyphal-Service-Client/OpenCyphal-Service-Client.ino
@@ -1,10 +1,6 @@
 /*
  * This example shows how to use the OpenCyphal library to request the performance of a
  * service from a service server.
- *
- * Hardware:
- *   - Arduino MKR family board, e.g. MKR VIDOR 4000
- *   - Arduino MKR CAN shield
  */
 
 /**************************************************************************************

--- a/examples/OpenCyphal-Service-Server/OpenCyphal-Service-Server.ino
+++ b/examples/OpenCyphal-Service-Server/OpenCyphal-Service-Server.ino
@@ -1,10 +1,6 @@
 /*
  * This example shows how to use the OpenCyphal library to set up a service server
  * responding to requests from service clients.
- *
- * Hardware:
- *   - Arduino MKR family board, e.g. MKR VIDOR 4000
- *   - Arduino MKR CAN shield
  */
 
 /**************************************************************************************


### PR DESCRIPTION
ArduinoCore-samd is no longer supported.