### PR TITLE
Clang fails due to `cbegin()` returning an iterator, not a pointer, when casting to `std::string_view`

### DIFF
--- a/src/util/registry/Registry.hpp
+++ b/src/util/registry/Registry.hpp
@@ -83,7 +83,7 @@ private:
 
   TAccessResponse onAccess_1_0_Request_Received(TAccessRequest const &req)
   {
-    auto const req_name = std::string_view(reinterpret_cast<const char *>(req.name.name.cbegin()),
+    auto const req_name = std::string_view(reinterpret_cast<const char *>(req.name.name.data()),
                                            req.name.name.size());
 
     /* Try to set the registers value. Note, if this is a RO register

--- a/src/util/storage/register_storage.hpp
+++ b/src/util/storage/register_storage.hpp
@@ -36,7 +36,7 @@ template <typename FeedWatchdogFunc>
 
         // Find the next register in the registry.
         const auto reg_name_storage = rgy.index(index);  // This is a little suboptimal but we don't care.
-        const auto reg_name = std::string_view(reinterpret_cast<const char *>(reg_name_storage.name.cbegin()), reg_name_storage.name.size());
+        const auto reg_name = std::string_view(reinterpret_cast<const char *>(reg_name_storage.name.data()), reg_name_storage.name.size());
         if (reg_name.empty())
         {
             break;  // No more registers to load.
@@ -107,7 +107,7 @@ template <typename ResetPredicate, typename FeedWatchdogFunc>
         feed_watchdog_func();
 
         const auto reg_name_storage = rgy.index(index);  // This is a little suboptimal but we don't care.
-        const auto reg_name = std::string_view(reinterpret_cast<const char *>(reg_name_storage.name.cbegin()), reg_name_storage.name.size());
+        const auto reg_name = std::string_view(reinterpret_cast<const char *>(reg_name_storage.name.data()), reg_name_storage.name.size());
         if (reg_name.empty())
         {
             break;  // No more registers to load.


### PR DESCRIPTION
cbegin() returns an iterator, which isn't exactly a pointer, causing clang to fail compilation on these lines. Use data() method instead.