### PR TITLE
Revert "Fix CI: disable report-size-deltas action."

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -56,10 +56,19 @@ jobs:
           fqbn: ${{ matrix.board.fqbn }}
           platforms: ${{ matrix.board.platforms }}
           libraries: ${{ env.LIBRARIES }}
+          enable-deltas-report: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
           sketch-paths: |
             - examples/CAN/OpenCyphal-Blink
             - examples/CAN/OpenCyphal-Heartbeat-Publisher
             - examples/CAN/OpenCyphal-Heartbeat-Subscriber
             - examples/CAN/OpenCyphal-Service-Client
             - examples/CAN/OpenCyphal-Service-Server
+
+      - name: Save memory usage change report as artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SKETCHES_REPORTS_PATH }}
+          path: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -35,20 +35,20 @@ jobs:
             platforms: |
               - name: rp2040:rp2040
                 source-url: https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
-            artifact-name-suffix: rp2040:arduino_nano_connect
+            artifact-name-suffix: rp2040-arduino-nano-connect
           - fqbn: rp2040:rp2040:rpipico
             platforms: |
               - name: rp2040:rp2040
                 source-url: https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
-            artifact-name-suffix: rp2040:rpipico
+            artifact-name-suffix: rp2040-rpipico
           - fqbn: arduino:renesas_portenta:portenta_c33
             platforms: |
               - name: arduino:renesas_portenta
-            artifact-name-suffix: renesas_portenta:portenta_c33
+            artifact-name-suffix: renesas-portenta-portenta-c33
           - fqbn: arduino:renesas_uno:minima
             platforms: |
               - name: arduino:renesas_uno
-            artifact-name-suffix: renesas_uno:minima
+            artifact-name-suffix: renesas-uno-minima
 
     steps:
       - name: Checkout

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -74,5 +74,5 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: sketches-report-${{ matrix.board.artifact-name-suffix }}
           path: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -35,16 +35,20 @@ jobs:
             platforms: |
               - name: rp2040:rp2040
                 source-url: https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+            artifact-name-suffix: rp2040:arduino_nano_connect
           - fqbn: rp2040:rp2040:rpipico
             platforms: |
               - name: rp2040:rp2040
                 source-url: https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+            artifact-name-suffix: rp2040:rpipico
           - fqbn: arduino:renesas_portenta:portenta_c33
             platforms: |
               - name: arduino:renesas_portenta
+            artifact-name-suffix: renesas_portenta:portenta_c33
           - fqbn: arduino:renesas_uno:minima
             platforms: |
               - name: arduino:renesas_uno
+            artifact-name-suffix: renesas_uno:minima
 
     steps:
       - name: Checkout

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,14 @@
+name: Report Size Deltas
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+
+    steps:
+      # See: https://github.com/arduino/report-size-deltas/README.md
+      - name: Comment size deltas reports to PRs
+        uses: arduino/report-size-deltas@main


### PR DESCRIPTION
Reverts 107-systems/107-Arduino-Cyphal#266

Use remedies described in https://github.com/arduino/report-size-deltas/blob/main/docs/FAQ.md#size-deltas-report-workflow-triggered-by-schedule-event .