### PR TITLE
Fix regression report-size-deltas after updating upload-artifact.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -74,5 +74,6 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: sketches-report-${{ matrix.board.artifact-name-suffix }}
+          if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: sketches-report-${{ matrix.board.artifact-name-suffix }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -10,5 +10,7 @@ jobs:
 
     steps:
       # See: https://github.com/arduino/report-size-deltas/README.md
-      - name: Comment size deltas reports to PRs
-        uses: arduino/report-size-deltas@main
+      uses: arduino/report-size-deltas@v1
+      with:
+        # Regex matching the names of the workflow artifacts created by the "Compile Examples" workflow
+        sketches-reports-source: ^sketches-report-.+


### PR DESCRIPTION
For more information see https://github.com/arduino/report-size-deltas/blob/main/docs/FAQ.md#size-deltas-report-workflow-triggered-by-schedule-event .