### PR TITLE
Replace compile-examples@main with compile-examples@v1.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Compile examples
-        uses: arduino/compile-sketches@main
+        uses: arduino/compile-sketches@v1
         with:
           fqbn: ${{ matrix.board.fqbn }}
           platforms: ${{ matrix.board.platforms }}


### PR DESCRIPTION
The released actions are guaranteed to work, while the version in main can - sometimes - break.