### PR TITLE
The ability to set the priority of sending messages has been implemented

### DIFF
--- a/src/Node.hpp
+++ b/src/Node.hpp
@@ -85,7 +85,11 @@ public:
   template <typename T>
   Publisher<T> create_publisher(CanardMicrosecond const tx_timeout_usec);
   template <typename T>
+  Publisher<T> create_publisher(CanardMicrosecond const tx_timeout_usec, CanardPriority const tx_priority);
+  template <typename T>
   Publisher<T> create_publisher(CanardPortID const port_id, CanardMicrosecond const tx_timeout_usec);
+  template <typename T>
+  Publisher<T> create_publisher(CanardPortID const port_id, CanardMicrosecond const tx_timeout_usec, CanardPriority const tx_priority);
 
   template <typename T, typename OnReceiveCb>
   Subscription create_subscription(OnReceiveCb&& on_receive_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);

--- a/src/Node.hpp
+++ b/src/Node.hpp
@@ -108,7 +108,11 @@ public:
   template <typename T_REQ, typename T_RSP, typename OnResponseCb>
   ServiceClient<T_REQ> create_service_client(CanardMicrosecond const tx_timeout_usec, OnResponseCb&& on_response_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
   template <typename T_REQ, typename T_RSP, typename OnResponseCb>
+  ServiceClient<T_REQ> create_service_client(CanardMicrosecond const tx_timeout_usec, OnResponseCb&& on_response_cb, CanardPriority const tx_priority, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
+  template <typename T_REQ, typename T_RSP, typename OnResponseCb>
   ServiceClient<T_REQ> create_service_client(CanardPortID const response_port_id, CanardMicrosecond const tx_timeout_usec, OnResponseCb&& on_response_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
+  template <typename T_REQ, typename T_RSP, typename OnResponseCb>
+  ServiceClient<T_REQ> create_service_client(CanardPortID const response_port_id, CanardMicrosecond const tx_timeout_usec, OnResponseCb&& on_response_cb, CanardPriority const tx_priority, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
 
 #if !defined(__GNUC__) || (__GNUC__ >= 11)
   Registry create_registry();

--- a/src/Node.hpp
+++ b/src/Node.hpp
@@ -99,7 +99,11 @@ public:
   template <typename T_REQ, typename T_RSP, typename OnRequestCb>
   ServiceServer create_service_server(CanardMicrosecond const tx_timeout_usec, OnRequestCb&& on_request_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
   template <typename T_REQ, typename T_RSP, typename OnRequestCb>
+  ServiceServer create_service_server(CanardMicrosecond const tx_timeout_usec, OnRequestCb&& on_request_cb, CanardPriority const tx_priority, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
+  template <typename T_REQ, typename T_RSP, typename OnRequestCb>
   ServiceServer create_service_server(CanardPortID const request_port_id, CanardMicrosecond const tx_timeout_usec, OnRequestCb&& on_request_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
+  template <typename T_REQ, typename T_RSP, typename OnRequestCb>
+  ServiceServer create_service_server(CanardPortID const request_port_id, CanardMicrosecond const tx_timeout_usec, OnRequestCb&& on_request_cb, CanardPriority const tx_priority, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);
 
   template <typename T_REQ, typename T_RSP, typename OnResponseCb>
   ServiceClient<T_REQ> create_service_client(CanardMicrosecond const tx_timeout_usec, OnResponseCb&& on_response_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);

--- a/src/Node.ipp
+++ b/src/Node.ipp
@@ -29,7 +29,14 @@ template <typename T>
 Publisher<T> Node::create_publisher(CanardMicrosecond const tx_timeout_usec)
 {
   static_assert(T::_traits_::HasFixedPortID, "T does not have a fixed port id.");
-  return create_publisher<T>(T::_traits_::FixedPortId, tx_timeout_usec);
+  return create_publisher<T>(T::_traits_::FixedPortId, tx_timeout_usec, CanardPriorityNominal);
+}
+
+template <typename T>
+Publisher<T> Node::create_publisher(CanardMicrosecond const tx_timeout_usec, CanardPriority const tx_priority)
+{
+  static_assert(T::_traits_::HasFixedPortID, "T does not have a fixed port id.");
+  return create_publisher<T>(T::_traits_::FixedPortId, tx_timeout_usec, tx_priority);
 }
 
 template <typename T>
@@ -43,7 +50,24 @@ Publisher<T> Node::create_publisher(CanardPortID const port_id, CanardMicrosecon
   return std::make_shared<impl::Publisher<T>>(
     *this,
     port_id,
-    tx_timeout_usec
+    tx_timeout_usec,
+    CanardPriorityNominal
+    );
+}
+
+template <typename T>
+Publisher<T> Node::create_publisher(CanardPortID const port_id, CanardMicrosecond const tx_timeout_usec, CanardPriority const tx_priority)
+{
+  static_assert(!T::_traits_::IsServiceType, "T is not message type");
+
+  if (_opt_port_list_pub.has_value())
+    _opt_port_list_pub.value()->add_publisher(port_id);
+
+  return std::make_shared<impl::Publisher<T>>(
+    *this,
+    port_id,
+    tx_timeout_usec,
+    tx_priority
     );
 }
 

--- a/src/Publisher.hpp
+++ b/src/Publisher.hpp
@@ -33,9 +33,10 @@ template <typename T>
 class Publisher final : public PublisherBase<T>
 {
 public:
-  Publisher(Node & node_hdl, CanardPortID const port_id, CanardMicrosecond const tx_timeout_usec)
+  Publisher(Node & node_hdl, CanardPortID const port_id, CanardMicrosecond const tx_timeout_usec, CanardPriority const tx_priority)
   : _node_hdl{node_hdl}
   , _port_id{port_id}
+  , _tx_priority{tx_priority}
   , _tx_timeout_usec{tx_timeout_usec}
   , _transfer_id{0}
   { }
@@ -46,6 +47,7 @@ public:
 private:
   Node & _node_hdl;
   CanardPortID const _port_id;
+  CanardPriority const _tx_priority;
   CanardMicrosecond const _tx_timeout_usec;
   CanardTransferID _transfer_id;
 };

--- a/src/Publisher.ipp
+++ b/src/Publisher.ipp
@@ -36,7 +36,7 @@ bool Publisher<T>::publish(T const & msg)
 #pragma GCC diagnostic ignored "-Wpedantic"
   CanardTransferMetadata const transfer_metadata =
   {
-    .priority       = CanardPriorityNominal,
+    .priority       = _tx_priority,
     .transfer_kind  = CanardTransferKindMessage,
     .port_id        = _port_id,
     .remote_node_id = CANARD_NODE_ID_UNSET,

--- a/src/ServiceClient.hpp
+++ b/src/ServiceClient.hpp
@@ -33,10 +33,11 @@ template<typename T_REQ, typename T_RSP, typename OnResponseCb>
 class ServiceClient final : public ServiceClientBase<T_REQ>
 {
 public:
-  ServiceClient(Node & node_hdl, CanardPortID const response_port_id, CanardMicrosecond const tx_timeout_usec, OnResponseCb on_response_cb)
+  ServiceClient(Node & node_hdl, CanardPortID const response_port_id, CanardMicrosecond const tx_timeout_usec, CanardPriority tx_priority, OnResponseCb on_response_cb)
   : _node_hdl{node_hdl}
   , _response_port_id{response_port_id}
   , _tx_timeout_usec{tx_timeout_usec}
+  , _tx_priority{tx_priority}
   , _on_response_cb{on_response_cb}
   , _transfer_id{0}
   { }
@@ -51,6 +52,7 @@ private:
   Node & _node_hdl;
   CanardPortID const _response_port_id;
   CanardMicrosecond const _tx_timeout_usec;
+  CanardPriority const _tx_priority;
   OnResponseCb _on_response_cb;
   CanardTransferID _transfer_id;
 };

--- a/src/ServiceClient.ipp
+++ b/src/ServiceClient.ipp
@@ -45,7 +45,7 @@ bool ServiceClient<T_REQ, T_RSP, OnResponseCb>::request(CanardNodeID const remot
 #pragma GCC diagnostic ignored "-Wpedantic"
   CanardTransferMetadata const transfer_metadata =
     {
-      .priority       = CanardPriorityNominal,
+      .priority       = _tx_priority,
       .transfer_kind  = CanardTransferKindRequest,
       .port_id        = _response_port_id,
       .remote_node_id = remote_node_id,

--- a/src/ServiceServer.hpp
+++ b/src/ServiceServer.hpp
@@ -33,10 +33,11 @@ template<typename T_REQ, typename T_RSP, typename OnRequestCb>
 class ServiceServer final : public ServiceServerBase
 {
 public:
-  ServiceServer(Node & node_hdl, CanardPortID const request_port_id, CanardMicrosecond const tx_timeout_usec, OnRequestCb on_request_cb)
+  ServiceServer(Node & node_hdl, CanardPortID const request_port_id, CanardMicrosecond const tx_timeout_usec, CanardPriority const tx_priority, OnRequestCb on_request_cb)
   : _node_hdl{node_hdl}
   , _request_port_id{request_port_id}
   , _tx_timeout_usec{tx_timeout_usec}
+  , _tx_priority{tx_priority}
   , _on_request_cb{on_request_cb}
   { }
   virtual ~ServiceServer();
@@ -49,6 +50,7 @@ private:
   Node & _node_hdl;
   CanardPortID const _request_port_id;
   CanardMicrosecond const _tx_timeout_usec;
+  CanardPriority const _tx_priority;
   OnRequestCb _on_request_cb;
 };
 

--- a/src/ServiceServer.ipp
+++ b/src/ServiceServer.ipp
@@ -65,7 +65,7 @@ bool ServiceServer<T_REQ, T_RSP, OnRequestCb>::onTransferReceived(CanardRxTransf
   /* Enqueue the transfer. */
   CanardTransferMetadata const transfer_metadata =
   {
-    .priority       = CanardPriorityNominal,
+    .priority       = _tx_priority,
     .transfer_kind  = CanardTransferKindResponse,
     .port_id        = transfer.metadata.port_id,
     .remote_node_id = transfer.metadata.remote_node_id,


### PR DESCRIPTION
The priority of sending messages is set by the constructor argument when allocating the appropriate publishers, clients, servers. Thus, content will be sent with a predefined priority, which cannot be changed at runtime.