### PR TITLE
Modify CMakeLists.txt to prevent undesired warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,8 @@ add_library(${PROJECT_NAME} STATIC
 ##########################################################################
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic -Werror)
 ##########################################################################
-target_include_directories(${PROJECT_NAME} PUBLIC src extras/cyphal++/include src/libcanard src/libo1heap)
+target_include_directories(${PROJECT_NAME} PRIVATE src extras/cyphal++/include src/libcanard src/libo1heap)
+target_include_directories(${PROJECT_NAME} SYSTEM INTERFACE src extras/cyphal++/include src/libcanard src/libo1heap)
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
 ##########################################################################
 if(BUILD_EXAMPLES)


### PR DESCRIPTION
Hello, I'm using this library as a part of my project. on the target where I import the library I've a different set of warning flags passed to the compiler that are more strict than the ones in the library. Although the ideal case will be to fix them that's a lot of work and probably not in the general interest of this repo.

What I propose is to add a minimal change so that when the library is linked to a target the flags from that target are not propagated to the library. A more in depth explanation can be found [here](https://www.foonathan.net/2018/10/cmake-warnings/).